### PR TITLE
Use post title as Babbel story title and keep it in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ WordPress plugin that automatically sends posts to the [Babbel API](https://gith
 ## Features
 
 - **ACF Integration**: Injects a "Radio News" checkbox into a specific ACF field group
-- **OpenAI Integration**: Uses GPT models to automatically generate short titles and speech text
+- **OpenAI Integration**: Uses GPT models to automatically generate speech text
 - **Settings Page**: Fully configurable prompts and API settings
 - **Async Processing**: Uses Action Scheduler for reliable background processing
 
@@ -29,8 +29,7 @@ WordPress plugin that automatically sends posts to the [Babbel API](https://gith
 1. Configure the plugin via Settings > ZuidWest Knabbel
 2. When editing a post, check "Radionieuws" in the ACF metabox
 3. On publish, the plugin automatically:
-   - Generates a short title via OpenAI
-   - Converts content to speech text
+   - Converts content to speech text via OpenAI
    - Creates a story in the Babbel API
 
 ## Development

--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -279,24 +279,9 @@ function metabox_save( int $post_id ): void {
 
 		// Restore soft-deleted story instead of creating new.
 		if ( $story_id && StoryStatus::Deleted->value === $status ) {
-			$result = babbel_restore_story( $story_id );
-			if ( $result['success'] ) {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Sent->value,
-						'message' => __( 'Story restored in Babbel', 'zw-knabbel-wp' ),
-					)
-				);
-			} else {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Error->value,
-						'message' => $result['message'],
-					)
-				);
-			}
+			$post  = get_post( $post_id );
+			$title = $post ? $post->post_title : '';
+			restore_and_sync_story( $post_id, $story_id, $title );
 			return;
 		}
 

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -62,7 +62,6 @@ function settings_register_settings(): void {
 				'api_password'      => '',
 				'openai_api_key'    => '',
 				'openai_model'      => 'gpt-4.1-mini',
-				'title_prompt'      => '',
 				'speech_prompt'     => '',
 				'debug_mode'        => false,
 				'start_days_offset' => 1,
@@ -105,7 +104,7 @@ function sanitize_settings( array $input ): array {
 	}
 
 	// Textarea fields (prompts) - preserve newlines.
-	$textarea_fields = array( 'title_prompt', 'speech_prompt' );
+	$textarea_fields = array( 'speech_prompt' );
 	foreach ( $textarea_fields as $field ) {
 		if ( isset( $input[ $field ] ) ) {
 			$sanitized[ $field ] = sanitize_textarea_field( $input[ $field ] );
@@ -315,7 +314,7 @@ function render_openai_card( array $settings ): void {
 		</div>
 		<div class="knabbel-card-content">
 			<p class="knabbel-card-description">
-				<?php esc_html_e( 'Configure OpenAI for generating titles and speech text.', 'zw-knabbel-wp' ); ?>
+				<?php esc_html_e( 'Configure OpenAI for generating speech text.', 'zw-knabbel-wp' ); ?>
 			</p>
 
 			<div class="knabbel-field">
@@ -394,28 +393,13 @@ function render_prompts_card( array $settings ): void {
 		</div>
 		<div class="knabbel-card-content">
 			<p class="knabbel-card-description">
-				<?php esc_html_e( 'Customize the AI prompts for generating titles and speech text.', 'zw-knabbel-wp' ); ?>
+				<?php esc_html_e( 'Customize the AI prompt for generating speech text.', 'zw-knabbel-wp' ); ?>
 			</p>
 
-			<div class="knabbel-field-row">
-				<div class="knabbel-field">
-					<label class="knabbel-field-label">
-						<?php esc_html_e( 'Title Generation Prompt', 'zw-knabbel-wp' ); ?>
-					</label>
-					<textarea name="knabbel_settings[title_prompt]"
-						class="knabbel-field-input"
-						rows="4"
-						<?php // phpcs:ignore Generic.Files.LineLength.TooLong -- Placeholder text with newlines ?>
-						placeholder="<?php echo esc_attr( "Creëer een pakkende radiotitel (max 60 karakters) die:\n- Direct de kernboodschap weergeeft\n- Nieuwswaardig en luisteraantrekkelijk is\n- Geschikt voor gesproken presentatie\n- Actief geformuleerd is" ); ?>"><?php echo esc_textarea( $settings['title_prompt'] ?? '' ); ?></textarea>
-					<p class="knabbel-field-description">
-						<?php esc_html_e( 'Prompt for generating radio-friendly titles. Leave empty for default prompt.', 'zw-knabbel-wp' ); ?>
-					</p>
-				</div>
-
-				<div class="knabbel-field">
-					<label class="knabbel-field-label">
-						<?php esc_html_e( 'Speech Text Generation Prompt', 'zw-knabbel-wp' ); ?>
-					</label>
+			<div class="knabbel-field">
+				<label class="knabbel-field-label">
+					<?php esc_html_e( 'Speech Text Generation Prompt', 'zw-knabbel-wp' ); ?>
+				</label>
 					<textarea name="knabbel_settings[speech_prompt]"
 						class="knabbel-field-input"
 						rows="4"
@@ -424,7 +408,6 @@ function render_prompts_card( array $settings ): void {
 					<p class="knabbel-field-description">
 						<?php esc_html_e( 'Prompt for converting to radio-friendly speech text. Leave empty for default prompt.', 'zw-knabbel-wp' ); ?>
 					</p>
-				</div>
 			</div>
 		</div>
 	</div>

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -560,6 +560,9 @@ function babbel_delete_story( string $story_id ): array {
 /**
  * Restore a soft-deleted story in the Babbel API.
  *
+ * The PATCH endpoint only accepts 'status' and 'deleted_at' fields.
+ * To update the title after restore, use babbel_update_story() separately.
+ *
  * @since 0.2.0
  * @param string $story_id The Babbel story ID.
  * @return array{success: bool, message: string} Response with success status and message.

--- a/includes/openai-handler.php
+++ b/includes/openai-handler.php
@@ -2,7 +2,7 @@
 /**
  * OpenAI API integration
  *
- * Handles content generation using OpenAI API for titles and speech text.
+ * Handles content generation using OpenAI API for speech text.
  *
  * @package KnabbelWP
  * @since   0.0.1
@@ -38,20 +38,15 @@ function openai_get_settings(): array {
  *
  * @since 0.1.0
  * @param string $content The source content.
- * @param string $type    The type of content to generate ('title' or 'speech').
  * @return string|null The generated content or null on failure.
  */
-function openai_generate_content( string $content, string $type = 'title' ): ?string {
+function openai_generate_content( string $content ): ?string {
 	$options = get_option( 'knabbel_settings' );
 
-	$prompts = array(
-		// phpcs:ignore Generic.Files.LineLength.TooLong -- Prompt text should remain on single line for clarity.
-		'title'  => 'Creëer een pakkende radiotitel (max 60 karakters) die:\n- Direct de kernboodschap weergeeft\n- Nieuwswaardig en luisteraantrekkelijk is\n- Geschikt voor gesproken presentatie\n- Actief geformuleerd is',
-		// phpcs:ignore Generic.Files.LineLength.TooLong -- Prompt text should remain on single line for clarity.
-		'speech' => 'Transformeer naar natuurlijke radiospreektekst met:\n- Korte, heldere zinnen (max 15 woorden)\n- Spreektaal en radiofrases\n- Logische volgorde voor luisteraars\n- Duidelijke overgangen tussen punten\n- Actieve zinsbouw\n- Getallen uitgeschreven waar natuurlijk',
-	);
+	// phpcs:ignore Generic.Files.LineLength.TooLong -- Prompt text should remain on single line for clarity.
+	$default_prompt = 'Transformeer naar natuurlijke radiospreektekst met:\n- Korte, heldere zinnen (max 15 woorden)\n- Spreektaal en radiofrases\n- Logische volgorde voor luisteraars\n- Duidelijke overgangen tussen punten\n- Actieve zinsbouw\n- Getallen uitgeschreven waar natuurlijk';
 
-	$prompt = $options[ $type . '_prompt' ] ?? $prompts[ $type ];
+	$prompt = $options['speech_prompt'] ?? $default_prompt;
 
 	$messages = array(
 		array(
@@ -60,10 +55,7 @@ function openai_generate_content( string $content, string $type = 'title' ): ?st
 		),
 	);
 
-	// Add few-shot examples for speech generation only.
-	if ( 'speech' === $type ) {
-		$messages = openai_add_few_shot_examples( $messages );
-	}
+	$messages = openai_add_few_shot_examples( $messages );
 
 	$messages[] = array(
 		'role'    => 'user',

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -239,24 +239,7 @@ function handle_checkbox_change( int $post_id, bool $was_enabled, bool $is_enabl
 
 		// Restore soft-deleted story instead of creating new.
 		if ( $story_id && StoryStatus::Deleted->value === $status ) {
-			$result = babbel_restore_story( $story_id );
-			if ( $result['success'] ) {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Sent->value,
-						'message' => __( 'Story restored in Babbel', 'zw-knabbel-wp' ),
-					)
-				);
-			} else {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Error->value,
-						'message' => $result['message'],
-					)
-				);
-			}
+			restore_and_sync_story( $post_id, $story_id, $post->post_title );
 			return;
 		}
 
@@ -311,24 +294,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 		if ( $send_to_babbel ) {
 			// Restore soft-deleted story instead of creating new.
 			if ( $story_id && StoryStatus::Deleted->value === $status ) {
-				$result = babbel_restore_story( $story_id );
-				if ( $result['success'] ) {
-					update_story_state(
-						$post_id,
-						array(
-							'status'  => StoryStatus::Sent->value,
-							'message' => __( 'Story restored in Babbel', 'zw-knabbel-wp' ),
-						)
-					);
-				} else {
-					update_story_state(
-						$post_id,
-						array(
-							'status'  => StoryStatus::Error->value,
-							'message' => $result['message'],
-						)
-					);
-				}
+				restore_and_sync_story( $post_id, $story_id, $post->post_title );
 				return;
 			}
 
@@ -348,6 +314,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 			$result = babbel_update_story(
 				$story_id,
 				array(
+					'title'      => $post->post_title,
 					'start_date' => $dates['start_date'],
 					'end_date'   => $dates['end_date'],
 					'weekdays'   => $dates['weekdays'],
@@ -358,7 +325,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 					$post_id,
 					array(
 						'status'  => StoryStatus::Sent->value,
-						'message' => __( 'Story dates updated (post published)', 'zw-knabbel-wp' ),
+						'message' => __( 'Story updated (post published)', 'zw-knabbel-wp' ),
 					)
 				);
 			} else {
@@ -366,7 +333,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 				log(
 					'error',
 					'PostHooks',
-					'Failed to update story dates on publish',
+					'Failed to update story on publish',
 					array(
 						'post_id' => $post_id,
 						'error'   => $result['message'],
@@ -384,24 +351,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 		if ( $send_to_babbel ) {
 			// Restore soft-deleted story instead of creating new.
 			if ( $story_id && StoryStatus::Deleted->value === $status ) {
-				$result = babbel_restore_story( $story_id );
-				if ( $result['success'] ) {
-					update_story_state(
-						$post_id,
-						array(
-							'status'  => StoryStatus::Sent->value,
-							'message' => __( 'Story restored in Babbel', 'zw-knabbel-wp' ),
-						)
-					);
-				} else {
-					update_story_state(
-						$post_id,
-						array(
-							'status'  => StoryStatus::Error->value,
-							'message' => $result['message'],
-						)
-					);
-				}
+				restore_and_sync_story( $post_id, $story_id, $post->post_title );
 				return;
 			}
 
@@ -413,26 +363,31 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 		return;
 	}
 
-	// Handle date changes for scheduled posts with existing stories (Quick Edit, REST API).
+	// Handle date/title changes for scheduled posts with existing stories (Quick Edit, REST API).
 	if ( 'future' === $new_status && 'future' === $old_status ) {
 		if ( $send_to_babbel && $story_id && StoryStatus::Sent->value === $status ) {
-			$old_date = null !== $post_before ? $post_before->post_date : null;
-			if ( $old_date !== $post->post_date ) {
-				$dates  = calculate_story_dates( $post->post_date );
-				$result = babbel_update_story(
-					$story_id,
-					array(
-						'start_date' => $dates['start_date'],
-						'end_date'   => $dates['end_date'],
-						'weekdays'   => $dates['weekdays'],
-					)
-				);
+			$old_date      = null !== $post_before ? $post_before->post_date : null;
+			$old_title     = null !== $post_before ? $post_before->post_title : null;
+			$date_changed  = $old_date !== $post->post_date;
+			$title_changed = $old_title !== $post->post_title;
+
+			if ( $date_changed || $title_changed ) {
+				$update_data = array( 'title' => $post->post_title );
+
+				if ( $date_changed ) {
+					$dates                     = calculate_story_dates( $post->post_date );
+					$update_data['start_date'] = $dates['start_date'];
+					$update_data['end_date']   = $dates['end_date'];
+					$update_data['weekdays']   = $dates['weekdays'];
+				}
+
+				$result = babbel_update_story( $story_id, $update_data );
 				if ( $result['success'] ) {
 					update_story_state(
 						$post_id,
 						array(
 							'status'  => StoryStatus::Sent->value,
-							'message' => __( 'Story dates updated in Babbel', 'zw-knabbel-wp' ),
+							'message' => __( 'Story updated in Babbel', 'zw-knabbel-wp' ),
 						)
 					);
 				} else {
@@ -440,7 +395,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 					log(
 						'error',
 						'PostHooks',
-						'Failed to update story dates (scheduled post)',
+						'Failed to update story (scheduled post)',
 						array(
 							'post_id' => $post_id,
 							'error'   => $result['message'],
@@ -452,29 +407,32 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 		return;
 	}
 
-	// Handle date changes for published posts with existing stories.
-	// Only update if the post_date actually changed (compare on Y-m-d level).
+	// Handle date/title changes for published posts with existing stories.
 	if ( 'publish' === $new_status && 'publish' === $old_status ) {
 		if ( $send_to_babbel && $story_id && StoryStatus::Sent->value === $status ) {
-			$old_date_ymd = null !== $post_before ? substr( $post_before->post_date, 0, 10 ) : null;
-			$new_date_ymd = substr( $post->post_date, 0, 10 );
+			$old_date_ymd  = null !== $post_before ? substr( $post_before->post_date, 0, 10 ) : null;
+			$new_date_ymd  = substr( $post->post_date, 0, 10 );
+			$old_title     = null !== $post_before ? $post_before->post_title : null;
+			$date_changed  = null !== $old_date_ymd && $old_date_ymd !== $new_date_ymd;
+			$title_changed = $old_title !== $post->post_title;
 
-			if ( null !== $old_date_ymd && $old_date_ymd !== $new_date_ymd ) {
-				$dates  = calculate_story_dates( $post->post_date );
-				$result = babbel_update_story(
-					$story_id,
-					array(
-						'start_date' => $dates['start_date'],
-						'end_date'   => $dates['end_date'],
-						'weekdays'   => $dates['weekdays'],
-					)
-				);
+			if ( $date_changed || $title_changed ) {
+				$update_data = array( 'title' => $post->post_title );
+
+				if ( $date_changed ) {
+					$dates                     = calculate_story_dates( $post->post_date );
+					$update_data['start_date'] = $dates['start_date'];
+					$update_data['end_date']   = $dates['end_date'];
+					$update_data['weekdays']   = $dates['weekdays'];
+				}
+
+				$result = babbel_update_story( $story_id, $update_data );
 				if ( $result['success'] ) {
 					update_story_state(
 						$post_id,
 						array(
 							'status'  => StoryStatus::Sent->value,
-							'message' => __( 'Story dates updated in Babbel', 'zw-knabbel-wp' ),
+							'message' => __( 'Story updated in Babbel', 'zw-knabbel-wp' ),
 						)
 					);
 				} else {
@@ -482,7 +440,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 					log(
 						'error',
 						'PostHooks',
-						'Failed to update story dates',
+						'Failed to update story',
 						array(
 							'post_id' => $post_id,
 							'error'   => $result['message'],
@@ -599,25 +557,68 @@ function handle_untrash_post( int $post_id ): void {
 
 	// Only restore if checkbox is enabled, we have a story_id, and it was deleted.
 	if ( $send_to_babbel && $story_id && StoryStatus::Deleted->value === $status ) {
-		$result = babbel_restore_story( $story_id );
-		if ( $result['success'] ) {
-			update_story_state(
-				$post_id,
-				array(
-					'status'  => StoryStatus::Sent->value,
-					'message' => __( 'Story restored in Babbel', 'zw-knabbel-wp' ),
-				)
-			);
-		} else {
-			update_story_state(
-				$post_id,
-				array(
-					'status'  => StoryStatus::Error->value,
-					'message' => $result['message'],
-				)
-			);
-		}
+		restore_and_sync_story( $post_id, $story_id, $post->post_title );
 	}
+}
+
+/**
+ * Restores a soft-deleted story and syncs the current post title.
+ *
+ * Uses PATCH to restore (deleted_at) then PUT to update the title,
+ * matching the Babbel API contract where PATCH only accepts status/deleted_at.
+ *
+ * @since 0.3.0
+ *
+ * @param int    $post_id  The post ID.
+ * @param string $story_id The Babbel story ID.
+ * @param string $title    The current post title to sync.
+ * @return array{success: bool, message: string} Response with success status and message.
+ */
+function restore_and_sync_story( int $post_id, string $story_id, string $title ): array {
+	$result = babbel_restore_story( $story_id );
+	if ( ! $result['success'] ) {
+		update_story_state(
+			$post_id,
+			array(
+				'status'  => StoryStatus::Error->value,
+				'message' => $result['message'],
+			)
+		);
+		return $result;
+	}
+
+	// Sync the current post title via PUT (PATCH only accepts status/deleted_at).
+	$title_result = babbel_update_story( $story_id, array( 'title' => $title ) );
+	if ( $title_result['success'] ) {
+		update_story_state(
+			$post_id,
+			array(
+				'status'  => StoryStatus::Sent->value,
+				'message' => __( 'Story restored in Babbel', 'zw-knabbel-wp' ),
+			)
+		);
+	} else {
+		// Keep 'sent' status - story is restored but title may be stale.
+		log(
+			'error',
+			'PostHooks',
+			'Story restored but title sync failed',
+			array(
+				'post_id'  => $post_id,
+				'story_id' => $story_id,
+				'error'    => $title_result['message'],
+			)
+		);
+		update_story_state(
+			$post_id,
+			array(
+				'status'  => StoryStatus::Sent->value,
+				'message' => __( 'Story restored, but title sync failed', 'zw-knabbel-wp' ),
+			)
+		);
+	}
+
+	return $result;
 }
 
 /**

--- a/languages/zw-knabbel-wp-nl_NL.po
+++ b/languages/zw-knabbel-wp-nl_NL.po
@@ -204,7 +204,7 @@ msgid "OpenAI"
 msgstr "OpenAI"
 
 #: includes/admin/settings.php:314
-msgid "Configure OpenAI for generating titles and speech text."
+msgid "Configure OpenAI for generating speech text."
 msgstr "Configureer OpenAI voor het genereren van titels en spreektekst."
 
 #: includes/admin/settings.php:319
@@ -230,18 +230,10 @@ msgid "AI Prompts"
 msgstr "AI-prompts"
 
 #: includes/admin/settings.php:371
-msgid "Customize the AI prompts for generating titles and speech text."
-msgstr "Pas de AI-prompts aan voor het genereren van titels en spreektekst."
+msgid "Customize the AI prompt for generating speech text."
+msgstr "Pas de AI-prompt aan voor het genereren van spreektekst."
 
-#: includes/admin/settings.php:377
-msgid "Title Generation Prompt"
-msgstr "Prompt voor titelgeneratie"
-
-#: includes/admin/settings.php:385
-msgid "Prompt for generating radio-friendly titles. Leave empty for default prompt."
-msgstr "Prompt voor het genereren van radiogeschikte titels. Laat leeg voor standaardprompt."
-
-#: includes/admin/settings.php:391
+#: includes/admin/settings.php:402
 msgid "Speech Text Generation Prompt"
 msgstr "Prompt voor spreektekstgeneratie"
 
@@ -456,10 +448,6 @@ msgstr "Bericht niet gevonden"
 #: zw-knabbel-wp.php:537
 msgid "Send to Babbel is disabled for this post"
 msgstr "Verzenden naar Babbel is uitgeschakeld voor dit bericht"
-
-#: zw-knabbel-wp.php:561
-msgid "Could not generate title"
-msgstr "Kon titel niet genereren"
 
 #: zw-knabbel-wp.php:574
 msgid "Could not generate speech text"

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -182,7 +182,7 @@ msgid "OpenAI"
 msgstr ""
 
 #: includes/admin/settings.php:314
-msgid "Configure OpenAI for generating titles and speech text."
+msgid "Configure OpenAI for generating speech text."
 msgstr ""
 
 #: includes/admin/settings.php:319
@@ -216,18 +216,10 @@ msgid "AI Prompts"
 msgstr ""
 
 #: includes/admin/settings.php:371
-msgid "Customize the AI prompts for generating titles and speech text."
+msgid "Customize the AI prompt for generating speech text."
 msgstr ""
 
-#: includes/admin/settings.php:377
-msgid "Title Generation Prompt"
-msgstr ""
-
-#: includes/admin/settings.php:385
-msgid "Prompt for generating radio-friendly titles. Leave empty for default prompt."
-msgstr ""
-
-#: includes/admin/settings.php:391
+#: includes/admin/settings.php:402
 msgid "Speech Text Generation Prompt"
 msgstr ""
 
@@ -476,10 +468,6 @@ msgstr ""
 
 #: zw-knabbel-wp.php:537
 msgid "Send to Babbel is disabled for this post"
-msgstr ""
-
-#: zw-knabbel-wp.php:561
-msgid "Could not generate title"
 msgstr ""
 
 #: zw-knabbel-wp.php:574

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,7 +15,7 @@ parameters:
     BabbelCredentials: 'array{base_url: string, username: string, password: string}'
     BabbelApiResponse: 'array{success: bool, message: string, story_id?: string}'
     StoryData: 'array{title: string, text: string, start_date: string, end_date: string, status?: string, weekdays?: int, metadata?: array<string, mixed>}'
-    StoryState: 'array{status?: string, story_id?: string, status_changed_at?: string, message?: string, generated_title?: string, generated_speech_text?: string}'
+    StoryState: 'array{status?: string, story_id?: string, status_changed_at?: string, message?: string, generated_speech_text?: string}'
     # OpenAI types
     OpenAISettings: 'array{api_key: string|null, model: string, api_base_url: string}'
     ChatMessage: 'array{role: string, content: string, name?: string}'

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -257,7 +257,6 @@ function activate(): void {
 			'api_password'      => '',
 			'openai_api_key'    => '',
 			'openai_model'      => 'gpt-4.1-mini',
-			'title_prompt'      => '',
 			'speech_prompt'     => '',
 			'debug_mode'        => false,
 			// Story defaults.
@@ -565,21 +564,11 @@ function process_story_async( int|array $post_id_or_args ): void {
 
 	$content = wp_strip_all_tags( $post->post_content );
 
-	// Generate title.
-	$title = openai_generate_content( $content, 'title' );
-	if ( null === $title ) {
-		update_story_state(
-			$post_id,
-			array(
-				'status'  => \KnabbelWP\StoryStatus::Error->value,
-				'message' => __( 'Could not generate title', 'zw-knabbel-wp' ),
-			)
-		);
-		return;
-	}
+	// Use the post title directly.
+	$title = get_the_title( $post_id );
 
 	// Generate speech text.
-	$speech_text = openai_generate_content( $content, 'speech' );
+	$speech_text = openai_generate_content( $content );
 	if ( null === $speech_text ) {
 		update_story_state(
 			$post_id,
@@ -625,7 +614,6 @@ function process_story_async( int|array $post_id_or_args ): void {
 				'status'                => \KnabbelWP\StoryStatus::Sent->value,
 				'story_id'              => $result['story_id'],
 				'message'               => __( 'Story created successfully', 'zw-knabbel-wp' ),
-				'generated_title'       => $title,
 				'generated_speech_text' => $speech_text,
 			)
 		);

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -566,8 +566,8 @@ function process_story_async( int|array $post_id_or_args ): void {
 
 	$content = wp_strip_all_tags( $post->post_content );
 
-	// Use the post title directly.
-	$title = get_the_title( $post_id );
+	// Use the raw post title directly (not get_the_title() which applies filters and prefixes).
+	$title = $post->post_title;
 
 	// Generate speech text.
 	$speech_text = openai_generate_content( $content );


### PR DESCRIPTION
## Summary

- Story title now comes from `$post->post_title` instead of OpenAI generation
- Removes the "Title Generation Prompt" setting, `title_prompt` default, `generated_title` metadata
- Simplifies `openai_generate_content()` to only handle speech text (removes `$type` parameter)
- Uses raw `$post->post_title` instead of `get_the_title()` to avoid filter/prefix contamination
- Propagates title changes to Babbel on post updates (publish→publish, future→future, future→publish)
- Syncs current post title on story restore via new `restore_and_sync_story()` helper
- Restore uses PATCH for `deleted_at` + separate PUT for title, matching the Babbel OpenAPI spec
- Logs and surfaces errors when title sync fails after a successful restore
- Updates translations, README, and documentation

## Test plan

- [ ] Publish a post with Radionieuws enabled, verify the Babbel story uses the WordPress post title
- [ ] Edit the title of a published post with an existing Babbel story, verify Babbel title updates
- [ ] Edit the title of a scheduled post with an existing Babbel story, verify Babbel title updates
- [ ] Trash and restore a post, verify the story is restored with the current title
- [ ] Disable and re-enable the Radionieuws checkbox, verify the restored story has the current title
- [ ] Check settings page no longer shows "Title Generation Prompt" textarea
- [ ] Verify speech text generation still works as before