### PR TITLE
Slim down legacy cleanup and remove completed migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ WordPress plugin that automatically sends posts to the [Babbel API](https://gith
 ## Features
 
 - **ACF Integration**: Injects a "Radio News" checkbox into a specific ACF field group
-- **OpenAI Integration**: Uses GPT models to automatically generate speech text
-- **Settings Page**: Fully configurable prompts and API settings
+- **OpenAI Integration**: Converts article text to radio-friendly speech text using GPT models
+- **Few-shot Learning**: Learns from editor corrections to improve speech text quality over time
+- **Title Sync**: Uses the WordPress post title as Babbel story title and keeps it in sync on edits
+- **Settings Page**: Configurable prompts, API settings, and story defaults
 - **Async Processing**: Uses Action Scheduler for reliable background processing
 
 ## Requirements
@@ -29,8 +31,10 @@ WordPress plugin that automatically sends posts to the [Babbel API](https://gith
 1. Configure the plugin via Settings > ZuidWest Knabbel
 2. When editing a post, check "Radionieuws" in the ACF metabox
 3. On publish, the plugin automatically:
+   - Uses the post title as the Babbel story title
    - Converts content to speech text via OpenAI
    - Creates a story in the Babbel API
+4. Title and date changes are synced to Babbel when you update the post
 
 ## Development
 

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -2,11 +2,13 @@
 /**
  * PHPStan Bootstrap File
  *
- * Defines constants that are normally defined in the main plugin file
- * to avoid PHPStan errors when analyzing individual files.
+ * Defines constants and function stubs for static analysis only.
+ * This file is NOT loaded at runtime and is excluded from release builds.
  *
  * @package KnabbelWP
  * @since   0.0.1
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -23,12 +23,15 @@ $wpdb->query(
 	OR option_name LIKE '_transient_timeout_knabbel_session_%'"
 );
 
-// Clean up recent errors log (temporary debug data).
+// Clean up temporary options.
 delete_option( 'knabbel_recent_errors' );
+delete_option( 'knabbel_migration_status_changed_at' );
+delete_option( 'knabbel_few_shot_examples' );
 
 // Clean up any remaining Action Scheduler jobs.
 if ( function_exists( 'as_unschedule_all_actions' ) ) {
 	as_unschedule_all_actions( 'knabbel_process_story', array(), 'zw-knabbel-wp' );
+	as_unschedule_all_actions( 'knabbel_sync_few_shot_examples', array(), 'zw-knabbel-wp' );
 }
 
 // Note: The following data is intentionally preserved:

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -3,7 +3,7 @@
  * Plugin Name: ZuidWest Knabbel
  * Plugin URI: https://github.com/oszuidwest/zw-knabbel-wp
  * Description: WordPress plugin om berichten naar de Babbel API te sturen voor het radionieuws. Ondersteunt OpenAI GPT-modellen voor AI-gegenereerde content.
- * Version: 0.3.1
+ * Version: 0.4.0
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Streekomroep ZuidWest

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -205,9 +205,6 @@ function calculate_story_dates( string $base_date = 'now' ): array {
 function init(): void {
 	load_plugin_textdomain( 'zw-knabbel-wp', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 
-	// Run migrations on upgrade (activation hook doesn't fire on updates).
-	migrate_status_changed_at();
-
 	// Register cron hook for async story processing (always, not just admin).
 	add_action( 'knabbel_process_story', __NAMESPACE__ . '\\process_story_async', 10, 1 );
 
@@ -283,9 +280,6 @@ function activate(): void {
 		// Cleanup all legacy data on activation.
 		cleanup_legacy_data();
 
-		// Run data migrations.
-		migrate_status_changed_at();
-
 		// Schedule nightly few-shot example sync.
 		few_shot_schedule_sync();
 }
@@ -308,178 +302,18 @@ function deactivate(): void {
 }
 
 /**
- * Comprehensive cleanup of all legacy data from previous plugin versions.
+ * Cleanup deprecated data on activation.
  *
- * Removes legacy meta fields, options, transients and debug data.
- * Safe to run multiple times.
+ * Safe to run multiple times. Can be removed once all installs are on 0.4.0+.
  *
  * @since 0.1.0
- * @global wpdb $wpdb WordPress database abstraction object.
  */
 function cleanup_legacy_data(): void {
-	global $wpdb;
-
-	// Remove legacy options-based debug keys.
-	$legacy_options = array(
-		'knabbel_last_cron_run',
-		'knabbel_last_cron_error',
-		'knabbel_last_cron_success',
-		'knabbel_last_story_data',
-		'knabbel_debug_logs',
-		'knabbel_recent_errors',
-		// Additional legacy options from older versions.
-		'knabbel_api_credentials',
-		'knabbel_openai_settings',
-		'knabbel_cached_settings',
-		'knabbel_version_check',
-		'knabbel_migration_status',
-	);
-
-	foreach ( $legacy_options as $option ) {
-		delete_option( $option );
-	}
-
-	// Remove all legacy per-post meta keys in single query.
-	$legacy_meta_keys = array(
-		'_zw_knabbel_babbel_status',
-		'_zw_knabbel_babbel_error',
-		'_zw_knabbel_babbel_story_id',
-		'_zw_knabbel_babbel_last_run',
-		'_zw_knabbel_babbel_last_success',
-		'_zw_knabbel_babbel_last_error',
-		'_zw_knabbel_babbel_last_story_data',
-		'_zw_knabbel_babbel_debug_payload',
-		// Additional legacy meta keys from older plugin versions.
-		'_zw_knabbel_babbel_processed',
-		'_zw_knabbel_babbel_retry_count',
-		'_zw_knabbel_babbel_locked',
-		'_zw_knabbel_babbel_queued_at',
-		'_zw_knabbel_old_status',
-		'_zw_knabbel_migration_done',
-		'_zw_knabbel_backup_data',
-	);
-
-	$placeholders = implode( ',', array_fill( 0, count( $legacy_meta_keys ), '%s' ) );
-	$wpdb->query(
-		$wpdb->prepare(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Dynamic placeholders.
-			'DELETE FROM ' . $wpdb->postmeta . ' WHERE meta_key IN (' . $placeholders . ')',
-			$legacy_meta_keys
-		)
-	);
-
-	// Clean up legacy session transients and cached data.
-	$wpdb->query(
-		$wpdb->prepare(
-			// phpcs:ignore Generic.Files.LineLength.TooLong -- SQL query readability.
-			'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s OR option_name LIKE %s OR option_name LIKE %s OR option_name LIKE %s',
-			'_transient_knabbel_session_%',
-			'_transient_timeout_knabbel_session_%',
-			'knabbel_session_%',
-			'_transient_knabbel_%',
-			'_transient_timeout_knabbel_%'
-		)
-	);
-
-	// Clean up legacy user meta keys (in case any user-specific data was stored).
-	$legacy_user_meta_keys = array(
-		'_zw_knabbel_user_preferences',
-		'_zw_knabbel_last_activity',
-		'_zw_knabbel_permission_cache',
-	);
-
-	$user_placeholders = implode( ',', array_fill( 0, count( $legacy_user_meta_keys ), '%s' ) );
-	$wpdb->query(
-		$wpdb->prepare(
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Dynamic placeholders.
-			'DELETE FROM ' . $wpdb->usermeta . ' WHERE meta_key IN (' . $user_placeholders . ')',
-			$legacy_user_meta_keys
-		)
-	);
-
 	// Remove deprecated title_prompt from settings (removed in 0.3.0).
 	$settings = get_option( 'knabbel_settings' );
 	if ( is_array( $settings ) && isset( $settings['title_prompt'] ) ) {
 		unset( $settings['title_prompt'] );
 		update_option( 'knabbel_settings', $settings );
-	}
-
-	// Clear any legacy cron jobs that might be stuck.
-	wp_clear_scheduled_hook( 'knabbel_legacy_cleanup' );
-	wp_clear_scheduled_hook( 'knabbel_old_process' );
-	wp_clear_scheduled_hook( 'knabbel_babbel_process' );
-
-	// Log cleanup completion with detailed stats.
-	log(
-		'info',
-		'Cleanup',
-		'Comprehensive legacy data cleanup completed on activation',
-		array(
-			'options_removed'        => count( $legacy_options ),
-			'post_meta_keys_removed' => count( $legacy_meta_keys ),
-			'user_meta_keys_removed' => count( $legacy_user_meta_keys ),
-			'cleanup_timestamp'      => current_time( 'mysql' ),
-		)
-	);
-}
-
-/**
- * Migrates story state data from updated_at to status_changed_at field.
- *
- * This migration runs once to rename the field for clarity.
- * Safe to run multiple times - skips already migrated records.
- *
- * @since 0.1.0
- * @global wpdb $wpdb WordPress database abstraction object.
- */
-function migrate_status_changed_at(): void {
-	global $wpdb;
-
-	// Check if migration already ran.
-	$migration_done = get_option( 'knabbel_migration_status_changed_at', false );
-	if ( $migration_done ) {
-		return;
-	}
-
-	// Find all posts with story state.
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time migration.
-	$results = $wpdb->get_results(
-		$wpdb->prepare(
-			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s",
-			'_zw_knabbel_story_state'
-		)
-	);
-
-	$migrated = 0;
-	foreach ( $results as $row ) {
-		$state = maybe_unserialize( $row->meta_value );
-		if ( ! is_array( $state ) ) {
-			continue;
-		}
-
-		// Skip if already migrated or no updated_at field.
-		if ( isset( $state['status_changed_at'] ) || ! isset( $state['updated_at'] ) ) {
-			continue;
-		}
-
-		// Rename the field.
-		$state['status_changed_at'] = $state['updated_at'];
-		unset( $state['updated_at'] );
-
-		update_post_meta( (int) $row->post_id, '_zw_knabbel_story_state', $state );
-		++$migrated;
-	}
-
-	// Mark migration as complete.
-	update_option( 'knabbel_migration_status_changed_at', true );
-
-	if ( $migrated > 0 ) {
-		log(
-			'info',
-			'Migration',
-			'Migrated updated_at to status_changed_at',
-			array( 'records_migrated' => $migrated )
-		);
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove `cleanup_legacy_data()` body: all legacy option, post meta, user meta, transient and cron hook cleanup is removed — these keys never existed in any released version
- Remove completed `migrate_status_changed_at()` migration and both call sites (pre-git migration, never needed in any release)
- Reduce `cleanup_legacy_data()` to only removing deprecated `title_prompt` from settings
- Add `knabbel_few_shot_examples`, `knabbel_migration_status_changed_at` and few-shot sync job cleanup to `uninstall.php`
- Suppress phpcs prefix warnings in PHPStan bootstrap stubs
- Update README with few-shot learning and title sync features
- Bump version to 0.4.0

Net result: 17 insertions, 174 deletions across 4 files.

**Note:** `knabbel_recent_errors` is no longer cleaned up on re-activation — only on uninstall. This is intentional: it preserves debug logs across reactivations.

## Test plan

- [x] Activate/deactivate plugin, verify no errors
- [x] Verify `title_prompt` is still cleaned from settings on activation
- [x] Delete plugin, verify few-shot examples option and scheduled jobs are removed