### PR TITLE
refactor: deduplicate story date update logic

### DIFF
--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -389,6 +389,7 @@ function babbel_test_connection(): array {
  * @param array{title?: string, start_date?: string, end_date?: string, weekdays?: int} $story_data The story data to update.
  * @return array{success: bool, message: string} Response with success status and message.
  *
+ * @phpstan-param StoryUpdateData $story_data
  * @phpstan-return BabbelApiResponse
  */
 function babbel_update_story( string $story_id, array $story_data ): array {

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -385,8 +385,8 @@ function babbel_test_connection(): array {
  * Update an existing story in the Babbel API.
  *
  * @since 0.2.0
- * @param string                                                        $story_id   The Babbel story ID.
- * @param array{start_date?: string, end_date?: string, weekdays?: int} $story_data The story data to update.
+ * @param string                                                                        $story_id   The Babbel story ID.
+ * @param array{title?: string, start_date?: string, end_date?: string, weekdays?: int} $story_data The story data to update.
  * @return array{success: bool, message: string} Response with success status and message.
  *
  * @phpstan-return BabbelApiResponse

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -345,21 +345,10 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 		return;
 	}
 
-	// Handle date/title changes for scheduled posts with existing stories (Quick Edit, REST API).
-	if ( 'future' === $new_status && 'future' === $old_status ) {
+	// Handle date/title changes for existing stories (same-status updates via Quick Edit, REST API).
+	if ( $new_status === $old_status && in_array( $new_status, array( 'future', 'publish' ), true ) ) {
 		if ( $send_to_babbel && $story_id && StoryStatus::Sent->value === $status ) {
-			$update_data = build_story_update_from_changes( $post, $post_before );
-			if ( $update_data ) {
-				push_story_update( $post_id, $story_id, $update_data, __( 'Story updated in Babbel', 'zw-knabbel-wp' ) );
-			}
-		}
-		return;
-	}
-
-	// Handle date/title changes for published posts with existing stories.
-	if ( 'publish' === $new_status && 'publish' === $old_status ) {
-		if ( $send_to_babbel && $story_id && StoryStatus::Sent->value === $status ) {
-			$update_data = build_story_update_from_changes( $post, $post_before, true );
+			$update_data = build_story_update_from_changes( $post, $post_before, 'publish' === $new_status );
 			if ( $update_data ) {
 				push_story_update( $post_id, $story_id, $update_data, __( 'Story updated in Babbel', 'zw-knabbel-wp' ) );
 			}

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -310,36 +310,18 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 	// Must come BEFORE the generic publish handler below, which would otherwise short-circuit.
 	if ( 'publish' === $new_status && 'future' === $old_status ) {
 		if ( $send_to_babbel && $story_id && StoryStatus::Sent->value === $status ) {
-			$dates  = calculate_story_dates( 'now' );
-			$result = babbel_update_story(
+			$dates = calculate_story_dates( 'now' );
+			push_story_update(
+				$post_id,
 				$story_id,
 				array(
 					'title'      => $post->post_title,
 					'start_date' => $dates['start_date'],
 					'end_date'   => $dates['end_date'],
 					'weekdays'   => $dates['weekdays'],
-				)
+				),
+				__( 'Story updated (post published)', 'zw-knabbel-wp' )
 			);
-			if ( $result['success'] ) {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Sent->value,
-						'message' => __( 'Story updated (post published)', 'zw-knabbel-wp' ),
-					)
-				);
-			} else {
-				// Keep 'sent' status on error - story still exists in Babbel.
-				log(
-					'error',
-					'PostHooks',
-					'Failed to update story on publish',
-					array(
-						'post_id' => $post_id,
-						'error'   => $result['message'],
-					)
-				);
-			}
 		}
 		// Don't return here - fall through to generic publish handler to handle
 		// cases where story doesn't exist yet (e.g., checkbox enabled on scheduled post
@@ -366,42 +348,9 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 	// Handle date/title changes for scheduled posts with existing stories (Quick Edit, REST API).
 	if ( 'future' === $new_status && 'future' === $old_status ) {
 		if ( $send_to_babbel && $story_id && StoryStatus::Sent->value === $status ) {
-			$old_date      = null !== $post_before ? $post_before->post_date : null;
-			$old_title     = null !== $post_before ? $post_before->post_title : null;
-			$date_changed  = $old_date !== $post->post_date;
-			$title_changed = $old_title !== $post->post_title;
-
-			if ( $date_changed || $title_changed ) {
-				$update_data = array( 'title' => $post->post_title );
-
-				if ( $date_changed ) {
-					$dates                     = calculate_story_dates( $post->post_date );
-					$update_data['start_date'] = $dates['start_date'];
-					$update_data['end_date']   = $dates['end_date'];
-					$update_data['weekdays']   = $dates['weekdays'];
-				}
-
-				$result = babbel_update_story( $story_id, $update_data );
-				if ( $result['success'] ) {
-					update_story_state(
-						$post_id,
-						array(
-							'status'  => StoryStatus::Sent->value,
-							'message' => __( 'Story updated in Babbel', 'zw-knabbel-wp' ),
-						)
-					);
-				} else {
-					// Keep 'sent' status on error - story still exists in Babbel.
-					log(
-						'error',
-						'PostHooks',
-						'Failed to update story (scheduled post)',
-						array(
-							'post_id' => $post_id,
-							'error'   => $result['message'],
-						)
-					);
-				}
+			$update_data = build_story_update_from_changes( $post, $post_before );
+			if ( $update_data ) {
+				push_story_update( $post_id, $story_id, $update_data, __( 'Story updated in Babbel', 'zw-knabbel-wp' ) );
 			}
 		}
 		return;
@@ -410,43 +359,9 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 	// Handle date/title changes for published posts with existing stories.
 	if ( 'publish' === $new_status && 'publish' === $old_status ) {
 		if ( $send_to_babbel && $story_id && StoryStatus::Sent->value === $status ) {
-			$old_date_ymd  = null !== $post_before ? substr( $post_before->post_date, 0, 10 ) : null;
-			$new_date_ymd  = substr( $post->post_date, 0, 10 );
-			$old_title     = null !== $post_before ? $post_before->post_title : null;
-			$date_changed  = null !== $old_date_ymd && $old_date_ymd !== $new_date_ymd;
-			$title_changed = $old_title !== $post->post_title;
-
-			if ( $date_changed || $title_changed ) {
-				$update_data = array( 'title' => $post->post_title );
-
-				if ( $date_changed ) {
-					$dates                     = calculate_story_dates( $post->post_date );
-					$update_data['start_date'] = $dates['start_date'];
-					$update_data['end_date']   = $dates['end_date'];
-					$update_data['weekdays']   = $dates['weekdays'];
-				}
-
-				$result = babbel_update_story( $story_id, $update_data );
-				if ( $result['success'] ) {
-					update_story_state(
-						$post_id,
-						array(
-							'status'  => StoryStatus::Sent->value,
-							'message' => __( 'Story updated in Babbel', 'zw-knabbel-wp' ),
-						)
-					);
-				} else {
-					// Keep 'sent' status on error - story still exists in Babbel.
-					log(
-						'error',
-						'PostHooks',
-						'Failed to update story',
-						array(
-							'post_id' => $post_id,
-							'error'   => $result['message'],
-						)
-					);
-				}
+			$update_data = build_story_update_from_changes( $post, $post_before, true );
+			if ( $update_data ) {
+				push_story_update( $post_id, $story_id, $update_data, __( 'Story updated in Babbel', 'zw-knabbel-wp' ) );
 			}
 		}
 		return;
@@ -619,6 +534,83 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
 	}
 
 	return $result;
+}
+
+/**
+ * Pushes a story update to Babbel and handles the result.
+ *
+ * Keeps 'sent' status on error since the story still exists in Babbel.
+ *
+ * @since 0.4.0
+ *
+ * @param int    $post_id         Post ID.
+ * @param string $story_id        Babbel story ID.
+ * @param array  $update_data     Data to send to babbel_update_story().
+ * @param string $success_message Translated message for the story state on success.
+ */
+function push_story_update( int $post_id, string $story_id, array $update_data, string $success_message ): void {
+	$result = babbel_update_story( $story_id, $update_data );
+	if ( $result['success'] ) {
+		update_story_state(
+			$post_id,
+			array(
+				'status'  => StoryStatus::Sent->value,
+				'message' => $success_message,
+			)
+		);
+	} else {
+		// Keep 'sent' status on error - story still exists in Babbel.
+		log(
+			'error',
+			'PostHooks',
+			'Failed to update story in Babbel',
+			array(
+				'post_id' => $post_id,
+				'error'   => $result['message'],
+			)
+		);
+	}
+}
+
+/**
+ * Detects date/title changes between post versions and builds update data.
+ *
+ * Returns null if nothing changed.
+ *
+ * @since 0.4.0
+ *
+ * @param \WP_Post      $post              Current post object.
+ * @param \WP_Post|null $post_before       Post object before the update.
+ * @param bool          $compare_date_only Whether to compare only the Y-m-d portion of the date.
+ * @return array|null Update data array for babbel_update_story(), or null if nothing changed.
+ */
+function build_story_update_from_changes( \WP_Post $post, ?\WP_Post $post_before, bool $compare_date_only = false ): ?array {
+	$old_title     = null !== $post_before ? $post_before->post_title : null;
+	$title_changed = $old_title !== $post->post_title;
+
+	if ( $compare_date_only ) {
+		$old_date_ymd = null !== $post_before ? substr( $post_before->post_date, 0, 10 ) : null;
+		$new_date_ymd = substr( $post->post_date, 0, 10 );
+		$date_changed = null !== $old_date_ymd && $old_date_ymd !== $new_date_ymd;
+	} else {
+		$old_date     = null !== $post_before ? $post_before->post_date : null;
+		$date_changed = $old_date !== $post->post_date;
+	}
+
+	if ( ! $date_changed && ! $title_changed ) {
+		return null;
+	}
+
+	$update_data = array( 'title' => $post->post_title );
+
+	if ( $date_changed ) {
+		$dates                     = calculate_story_dates( $post->post_date );
+		$update_data['start_date'] = $dates['start_date'];
+		$update_data['end_date']   = $dates['end_date'];
+		$update_data['weekdays']   = $dates['weekdays'];
+	}
+
+	return $update_data;
 }
 
 /**

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -532,10 +532,10 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
  *
  * @since 0.4.0
  *
- * @param int    $post_id         Post ID.
- * @param string $story_id        Babbel story ID.
- * @param array  $update_data     Data to send to babbel_update_story().
- * @param string $success_message Translated message for the story state on success.
+ * @param int                  $post_id         Post ID.
+ * @param string               $story_id        Babbel story ID.
+ * @param array<string, mixed> $update_data Data to send to babbel_update_story().
+ * @param string               $success_message Translated message for the story state on success.
  */
 function push_story_update( int $post_id, string $story_id, array $update_data, string $success_message ): void {
 	$result = babbel_update_story( $story_id, $update_data );
@@ -571,7 +571,7 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
  * @param \WP_Post      $post              Current post object.
  * @param \WP_Post|null $post_before       Post object before the update.
  * @param bool          $compare_date_only Whether to compare only the Y-m-d portion of the date.
- * @return array|null Update data array for babbel_update_story(), or null if nothing changed.
+ * @return array<string, mixed>|null Update data array for babbel_update_story(), or null if nothing changed.
  */
 function build_story_update_from_changes( \WP_Post $post, ?\WP_Post $post_before, bool $compare_date_only = false ): ?array {
 	$old_title     = null !== $post_before ? $post_before->post_title : null;

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -320,7 +320,8 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 					'end_date'   => $dates['end_date'],
 					'weekdays'   => $dates['weekdays'],
 				),
-				__( 'Story updated (post published)', 'zw-knabbel-wp' )
+				__( 'Story updated (post published)', 'zw-knabbel-wp' ),
+				'future_to_publish'
 			);
 		}
 		// Don't return here - fall through to generic publish handler to handle
@@ -345,12 +346,18 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 		return;
 	}
 
-	// Handle date/title changes for existing stories (same-status updates via Quick Edit, REST API).
+	// Handle date/title changes for existing stories - same-status saves from any context (editor update, Quick Edit, REST API, CLI).
 	if ( $new_status === $old_status && in_array( $new_status, array( 'future', 'publish' ), true ) ) {
-		if ( $send_to_babbel && $story_id && StoryStatus::Sent->value === $status ) {
+		if ( $send_to_babbel && $story_id && StoryStatus::Sent->value === $status && null !== $post_before ) {
 			$update_data = build_story_update_from_changes( $post, $post_before, 'publish' === $new_status );
 			if ( $update_data ) {
-				push_story_update( $post_id, $story_id, $update_data, __( 'Story updated in Babbel', 'zw-knabbel-wp' ) );
+				push_story_update(
+					$post_id,
+					$story_id,
+					$update_data,
+					__( 'Story updated in Babbel', 'zw-knabbel-wp' ),
+					'publish' === $new_status ? 'published_post_edit' : 'scheduled_post_edit'
+				);
 			}
 		}
 		return;
@@ -528,16 +535,19 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
 /**
  * Pushes a story update to Babbel and handles the result.
  *
- * Keeps 'sent' status on error since the story still exists in Babbel.
+ * On failure, logs the error and leaves the story state untouched: the status
+ * stays 'sent' since the story still exists in Babbel (unlike delete failures,
+ * which set an error state).
  *
  * @since 0.4.0
  *
  * @param int                  $post_id         Post ID.
  * @param string               $story_id        Babbel story ID.
- * @param array<string, mixed> $update_data Data to send to babbel_update_story().
+ * @param array<string, mixed> $update_data     Data to send to babbel_update_story().
  * @param string               $success_message Translated message for the story state on success.
+ * @param string               $log_context     Untranslated code-path label for the failure log.
  */
-function push_story_update( int $post_id, string $story_id, array $update_data, string $success_message ): void {
+function push_story_update( int $post_id, string $story_id, array $update_data, string $success_message, string $log_context ): void {
 	$result = babbel_update_story( $story_id, $update_data );
 	if ( $result['success'] ) {
 		update_story_state(
@@ -548,14 +558,16 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
 			)
 		);
 	} else {
-		// Keep 'sent' status on error - story still exists in Babbel.
 		log(
 			'error',
 			'PostHooks',
 			'Failed to update story in Babbel',
 			array(
-				'post_id' => $post_id,
-				'error'   => $result['message'],
+				'post_id'  => $post_id,
+				'story_id' => $story_id,
+				'context'  => $log_context,
+				'fields'   => array_keys( $update_data ),
+				'error'    => $result['message'],
 			)
 		);
 	}
@@ -564,26 +576,27 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
 /**
  * Detects date/title changes between post versions and builds update data.
  *
- * Returns null if nothing changed.
+ * With $compare_date_only, only the calendar day (Y-m-d) is compared so that
+ * time-only edits do not push an update (used for published posts). The
+ * full-datetime comparison (scheduled posts) does push on a time-only edit,
+ * which also resends dates derived from the current plugin settings.
  *
  * @since 0.4.0
  *
- * @param \WP_Post      $post              Current post object.
- * @param \WP_Post|null $post_before       Post object before the update.
- * @param bool          $compare_date_only Whether to compare only the Y-m-d portion of the date.
- * @return array<string, mixed>|null Update data array for babbel_update_story(), or null if nothing changed.
+ * @param \WP_Post $post              Current post object.
+ * @param \WP_Post $post_before       Post object before the update.
+ * @param bool     $compare_date_only Whether to ignore time-of-day changes and compare only the calendar day.
+ * @return array<string, mixed>|null Update data for babbel_update_story(), or null if nothing
+ *                                   changed. Always includes 'title'; start/end dates and
+ *                                   weekdays only when the date changed.
  */
-function build_story_update_from_changes( \WP_Post $post, ?\WP_Post $post_before, bool $compare_date_only = false ): ?array {
-	$old_title     = null !== $post_before ? $post_before->post_title : null;
-	$title_changed = $old_title !== $post->post_title;
+function build_story_update_from_changes( \WP_Post $post, \WP_Post $post_before, bool $compare_date_only ): ?array {
+	$title_changed = $post_before->post_title !== $post->post_title;
 
 	if ( $compare_date_only ) {
-		$old_date_ymd = null !== $post_before ? substr( $post_before->post_date, 0, 10 ) : null;
-		$new_date_ymd = substr( $post->post_date, 0, 10 );
-		$date_changed = null !== $old_date_ymd && $old_date_ymd !== $new_date_ymd;
+		$date_changed = substr( $post_before->post_date, 0, 10 ) !== substr( $post->post_date, 0, 10 );
 	} else {
-		$old_date     = null !== $post_before ? $post_before->post_date : null;
-		$date_changed = $old_date !== $post->post_date;
+		$date_changed = $post_before->post_date !== $post->post_date;
 	}
 
 	if ( ! $date_changed && ! $title_changed ) {

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -546,6 +546,8 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
  * @param array<string, mixed> $update_data     Data to send to babbel_update_story().
  * @param string               $success_message Translated message for the story state on success.
  * @param string               $log_context     Untranslated code-path label for the failure log.
+ *
+ * @phpstan-param StoryUpdateData $update_data
  */
 function push_story_update( int $post_id, string $story_id, array $update_data, string $success_message, string $log_context ): void {
 	$result = babbel_update_story( $story_id, $update_data );
@@ -589,6 +591,8 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
  * @return array<string, mixed>|null Update data for babbel_update_story(), or null if nothing
  *                                   changed. Always includes 'title'; start/end dates and
  *                                   weekdays only when the date changed.
+ *
+ * @phpstan-return StoryUpdateData|null
  */
 function build_story_update_from_changes( \WP_Post $post, \WP_Post $post_before, bool $compare_date_only ): ?array {
 	$title_changed = $post_before->post_title !== $post->post_title;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,7 @@ parameters:
     BabbelCredentials: 'array{base_url: string, username: string, password: string}'
     BabbelApiResponse: 'array{success: bool, message: string, story_id?: string}'
     StoryData: 'array{title: string, text: string, start_date: string, end_date: string, status?: string, weekdays?: int, metadata?: array<string, mixed>}'
+    StoryUpdateData: 'array{title?: string, start_date?: string, end_date?: string, weekdays?: int}'
     StoryState: 'array{status?: string, story_id?: string, status_changed_at?: string, message?: string, generated_speech_text?: string}'
     # OpenAI types
     OpenAISettings: 'array{api_key: string|null, model: string, api_base_url: string}'


### PR DESCRIPTION
## Summary

- Extract `push_story_update()` helper for the repeated "call Babbel API + handle success/error state" pattern
- Extract `build_story_update_from_changes()` helper for the repeated date/title change detection + update data construction
- Merge the identical `future→future` and `publish→publish` same-status update blocks into one

## What changed

The three story update blocks in `handle_post_saved()` (future→publish, future→future, publish→publish) shared ~20 lines of duplicated API call + state handling each. Now each block is a thin caller into shared helpers.

Net result: **-110 lines** of duplicated logic replaced by two focused helpers.

## Test plan

- [ ] Verify scheduled post date change syncs to Babbel (future→future)
- [ ] Verify published post date/title change syncs to Babbel (publish→publish)  
- [ ] Verify scheduled post publishing recalculates dates with "now" (future→publish)
- [ ] Verify API errors are logged without changing story status

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved story synchronization when moving posts from draft to published and when editing published stories.
  * More reliable change detection for title and dates, including day-only date adjustments for published items.
  * Standardized how success and failure are handled during story updates to prevent incorrect state changes on errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->