### PR TITLE
feat: adopt strict wp-templates @v2

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,0 +1,29 @@
+---
+name: JS Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.css'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'biome.json'
+  pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.css'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'biome.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-js-ci.yml@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,116 +1,33 @@
+---
 name: Lint
 
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - '**/*.php'
-      - '**/*.js'
-      - '**/*.css'
       - 'composer.json'
       - 'composer.lock'
-      - 'package.json'
-      - 'biome.json'
+      - 'phpcs.xml'
+      - 'phpcs.xml.dist'
       - 'phpstan.neon'
-      - 'languages/*.pot'
+      - 'phpstan-bootstrap.php'
+      - 'languages/**'
   pull_request:
     paths:
       - '**/*.php'
-      - '**/*.js'
-      - '**/*.css'
       - 'composer.json'
       - 'composer.lock'
-      - 'package.json'
-      - 'biome.json'
+      - 'phpcs.xml'
+      - 'phpcs.xml.dist'
       - 'phpstan.neon'
-      - 'languages/*.pot'
+      - 'phpstan-bootstrap.php'
+      - 'languages/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  php:
-    name: PHP ${{ matrix.php }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: ["8.3", "8.4"]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: curl
-          coverage: none
-          tools: composer:v2, cs2pr
-
-      - name: Validate PHP syntax
-        run: find . -maxdepth 1 -name '*.php' -exec php --syntax-check {} +
-
-      - name: Validate composer.json
-        run: composer validate --no-check-publish
-
-      - run: composer install --no-progress --prefer-dist --optimize-autoloader --no-suggest
-
-      - run: vendor/bin/phpcs -q --report=checkstyle | cs2pr
-
-      - run: ./vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr
-
-      - name: Run wp-plugin-check
-        if: matrix.php == '8.3'
-        uses: wordpress/plugin-check-action@v1
-        with:
-          exclude-checks: |
-            late_escaping
-            plugin_review_phpcs
-            file_type
-            plugin_readme
-
-  biome:
-    name: Biome
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-
-      - run: npm ci
-
-      - run: npm run lint
-
-  translations:
-    name: Translations
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.3"
-          tools: wp-cli
-
-      - name: Check for missing translation strings
-        run: |
-          # Generate fresh POT file
-          wp i18n make-pot . languages/zw-knabbel-wp-new.pot --slug=zw-knabbel-wp --domain=zw-knabbel-wp --skip-audit
-
-          # Extract msgid lines from both files
-          grep "^msgid " languages/zw-knabbel-wp.pot | sort > /tmp/old-strings.txt
-          grep "^msgid " languages/zw-knabbel-wp-new.pot | sort > /tmp/new-strings.txt
-
-          # Find strings in code but not in POT file
-          MISSING=$(comm -13 /tmp/old-strings.txt /tmp/new-strings.txt)
-
-          if [ -n "$MISSING" ]; then
-            echo "::error::Missing translation strings in POT file:"
-            echo "$MISSING"
-            echo ""
-            echo "Run 'wp i18n make-pot . languages/zw-knabbel-wp.pot' to update"
-            exit 1
-          fi
-
-          echo "All translation strings are present in POT file"
+  lint:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-ci.yml@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,126 +1,21 @@
-name: Publish Plugin Release
+---
+name: Release
+
 on:
   workflow_dispatch:
     inputs:
-      force_release:
-        description: 'Force release even if version unchanged'
+      force:
+        description: 'Release even if the version was not bumped'
         type: boolean
         default: false
-        required: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  validate-and-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Extract Version from Main Plugin File
-        id: extract_version
-        run: |
-          VERSION=$(sed -n 's/.*Version:\s*\([0-9.]\+\).*/\1/p' zw-knabbel-wp.php | head -1)
-          if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
-            echo "Error: Invalid version format - $VERSION"
-            exit 1
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Fetch and Validate Latest Tag
-        id: tag_validation
-        run: |
-          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "")
-          echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
-
-      - name: Compare Versions and Decide Release
-        id: release_decision
-        env:
-          FORCE_RELEASE: ${{ github.event.inputs.force_release }}
-        run: |
-          version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
-          RELEASE_NEEDED=false
-          if [[ "$FORCE_RELEASE" == "true" ]]; then
-            RELEASE_NEEDED=true
-          elif [[ -z "$LATEST_TAG" ]]; then
-            RELEASE_NEEDED=true
-          elif version_gt "$VERSION" "$LATEST_TAG"; then
-            RELEASE_NEEDED=true
-          else
-            RELEASE_NEEDED=false
-          fi
-          echo "RELEASE_NEEDED=$RELEASE_NEEDED" >> $GITHUB_ENV
-
-      - name: Stop if No Release Needed
-        if: env.RELEASE_NEEDED == 'false'
-        run: |
-          echo "Skipping release: No new version detected"
-          exit 0
-
-      - name: Tag the New Version
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git tag ${{ env.VERSION }}
-          git push origin ${{ env.VERSION }}
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          tools: composer
-
-      - name: Install Production Dependencies
-        run: composer install --no-dev --optimize-autoloader
-
-      - name: Compile translations
-        run: |
-          sudo apt-get install -y gettext
-          for po_file in languages/*.po; do
-            if [ -f "$po_file" ]; then
-              mo_file="${po_file%.po}.mo"
-              msgfmt -o "$mo_file" "$po_file"
-              echo "Compiled: $mo_file"
-            fi
-          done
-
-      - name: Set Plugin Name
-        run: |
-          PLUGIN_NAME="zw-knabbel-wp"
-          echo "PLUGIN_NAME=$PLUGIN_NAME" >> $GITHUB_ENV
-
-      - name: Prepare Release Directory
-        run: |
-          mkdir -p release/${{ env.PLUGIN_NAME }}
-          rsync -av --progress . ./release/${{ env.PLUGIN_NAME }} \
-            --exclude release \
-            --exclude .git \
-            --exclude .github \
-            --exclude node_modules \
-            --exclude composer.json \
-            --exclude composer.lock \
-            --exclude phpcs.xml \
-            --exclude phpstan.neon \
-            --exclude phpstan-bootstrap.php \
-            --exclude '*.log' \
-            --exclude '.gitignore' \
-            --exclude '.claude' \
-            --exclude 'CLAUDE.md' \
-            --exclude 'AGENTS.md'
-
-      - name: Create Zip Package
-        run: |
-          cd release
-          zip -r "../${{ env.PLUGIN_NAME }}-${{ env.VERSION }}.zip" ${{ env.PLUGIN_NAME }}
-          cd ..
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create ${{ env.VERSION }} \
-            "${{ env.PLUGIN_NAME }}-${{ env.VERSION }}.zip" \
-            --title "${{ env.VERSION }}" \
-            --generate-notes
+  release:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-release.yml@v2
+    with:
+      force: ${{ inputs.force }}
+    permissions:
+      contents: write


### PR DESCRIPTION
Migrates this plugin's CI/release workflows onto the strict reusables in oszuidwest/.github-templates@v2.

## What changed

- **`lint.yml`** → `wp-ci.yml@v2` (PHP 8.3 + 8.4 matrix, phpcs, phpstan, wp-plugin-check, translations job auto-detects `languages/zw-knabbel-wp.pot`).
- **`release.yml`** → `wp-release.yml@v2` (manual workflow_dispatch + version-bump detection; `msgfmt` auto-runs over `languages/*.po`).
- **`lint-js.yml`** → new caller of `wp-js-ci.yml@v2` for the biome `assets/` check (the strict templates split PHP and JS into separate workflows).

## Notes

- `phpstan-bootstrap.php` stays as-is. Its existing `if ( ! defined( 'ABSPATH' ) ) { exit; }` guard satisfies plugin-check, so the `.stub` workaround used in zw-cacheman / zw-ttvgpt isn't needed here.
- Plugin slug equals the repo name — no `plugin-slug` override needed.
- This shape was smoke-tested in oszuidwest/zw-knabbel-wp#14 (already closed) so all green is expected.

## Test plan

- [ ] CI on this PR runs Lint (PHP 8.3, PHP 8.4, Translations) and JS Lint.
- [ ] After merge, dispatch Release with `force=false` — should skip (header `0.4.0` equals latest tag `0.4.0`).