### PR TITLE
chore: require WordPress 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ WordPress plugin that automatically sends posts to the [Babbel API](https://gith
 
 ## Requirements
 
-- WordPress 6.8+
+- WordPress 7.0+
 - PHP 8.3 or 8.4
 - [Advanced Custom Fields](https://www.advancedcustomfields.com/) (ACF)
 - OpenAI API access

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,7 +16,7 @@
 
     <!-- Versions -->
     <config name="testVersion" value="8.3-8.4"/>
-    <config name="minimum_wp_version" value="6.8"/>
+    <config name="minimum_wp_version" value="7.0"/>
 
     <!-- Per-plugin -->
     <config name="text_domain" value="zw-knabbel-wp"/>

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/oszuidwest/zw-knabbel-wp
  * Description: WordPress plugin om berichten naar de Babbel API te sturen voor het radionieuws. Ondersteunt OpenAI GPT-modellen voor AI-gegenereerde content.
  * Version: 0.4.0
- * Requires at least: 6.8
+ * Requires at least: 7.0
  * Requires PHP: 8.3
  * Author: Streekomroep ZuidWest
  * Author URI: https://www.zuidwesttv.nl


### PR DESCRIPTION
## Summary

- Raise the plugin header and documented minimum WordPress version from 6.8 to 7.0.

## Compatibility audit

- Reviewed the WordPress 6.7, 6.8, 6.9, and 7.0 developer field guides, including the current WordPress 7.0.2 maintenance release.
- Checked the plugin's WordPress API calls against Core functions removed or deprecated through 7.0.
- Ran Plugin Check 2.0.0 in update mode and reviewed the findings for runtime relevance.
- Activated the plugin alongside the complete oszuidwest plugin set on WordPress 7.0.2 and PHP 8.3.32.

The audit found no additional WordPress 7 code changes required.

## Verification

- PHPStan
- Biome lint
- PHP syntax check
- Plugin Check 2.0.0 review
- Full-set activation on WordPress 7.0.2 / PHP 8.3.32

## References

- [WordPress 6.7 field guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/)
- [WordPress 6.8 field guide](https://make.wordpress.org/core/2025/03/28/wordpress-6-8-field-guide/)
- [WordPress 6.9 field guide](https://make.wordpress.org/core/2025/11/25/wordpress-6-9-field-guide/)
- [WordPress 7.0 field guide](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/)
- [WordPress 7.0.2 release](https://wordpress.org/news/2026/07/wordpress-7-0-2-release/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum supported WordPress version to **7.0**.
* **Documentation**
  * Updated the requirements information to reflect the new WordPress version support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->