### PR TITLE
refactor: deduplicate story delete handling

### DIFF
--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -188,8 +188,7 @@ function metabox_render_status( \WP_Post $post ): void {
  *
  * This function handles:
  * - Saving the checkbox meta value
- * - Deleting from Babbel when checkbox is unchecked
- * - Updating dates in Babbel when checkbox is checked and story exists
+ * - Delegating checkbox state changes to the shared synchronization handler
  *
  * Story creation is handled by handle_post_saved() to support scheduled posts.
  *
@@ -233,64 +232,5 @@ function metabox_save( int $post_id ): void {
 	update_post_meta( $post_id, '_zw_knabbel_send_to_babbel', $send_to_babbel );
 	unset( $GLOBALS['knabbel_skip_meta_sync'] );
 
-	// Get current story state.
-	$state    = get_story_state( $post_id );
-	$status   = $state['status'] ?? '';
-	$story_id = (string) ( $state['story_id'] ?? '' );
-
-	// Handle checkbox being unchecked.
-	if ( $was_enabled && ! $send_to_babbel ) {
-		// Cancel any pending processing jobs.
-		\as_unschedule_all_actions( 'knabbel_process_story', array( 'post_id' => $post_id ), 'zw-knabbel-wp' );
-
-		// Delete from Babbel if story was sent.
-		if ( $story_id && StoryStatus::Sent->value === $status ) {
-			$result = babbel_delete_story( $story_id );
-			if ( $result['success'] ) {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Deleted->value,
-						'message' => __( 'Story deleted from Babbel', 'zw-knabbel-wp' ),
-					)
-				);
-			} else {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Error->value,
-						'message' => $result['message'],
-					)
-				);
-			}
-		} elseif ( in_array( $status, array( StoryStatus::Scheduled->value, StoryStatus::Processing->value ), true ) ) {
-			// Clear pending state if job was cancelled.
-			delete_post_meta( $post_id, '_zw_knabbel_story_state' );
-		}
-		return;
-	}
-
-	// Handle checkbox being enabled on already published/scheduled post.
-	if ( ! $was_enabled && $send_to_babbel ) {
-		$post_status = get_post_status( $post_id );
-		if ( ! in_array( $post_status, array( 'publish', 'future' ), true ) ) {
-			return;
-		}
-
-		// Restore soft-deleted story instead of creating new.
-		if ( $story_id && StoryStatus::Deleted->value === $status ) {
-			$post  = get_post( $post_id );
-			$title = $post ? $post->post_title : '';
-			restore_and_sync_story( $post_id, $story_id, $title );
-			return;
-		}
-
-		// Create new story if not already sent/scheduled/processing.
-		if ( ! in_array( $status, array( StoryStatus::Sent->value, StoryStatus::Scheduled->value, StoryStatus::Processing->value ), true ) ) {
-			schedule_story_processing( $post_id );
-		}
-	}
-
-	// Note: Date updates for existing stories are handled in handle_post_saved()
-	// which has access to $post_before for detecting actual date changes.
+	handle_checkbox_change( $post_id, $was_enabled, (bool) $send_to_babbel );
 }

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -207,7 +207,7 @@ function handle_checkbox_change( int $post_id, bool $was_enabled, bool $is_enabl
 
 		// Delete from Babbel if story was sent.
 		if ( $story_id && StoryStatus::Sent->value === $status ) {
-			push_story_delete( $post_id, $story_id, __( 'Story deleted from Babbel', 'zw-knabbel-wp' ) );
+			push_story_delete( $post_id, $story_id, __( 'Story deleted from Babbel', 'zw-knabbel-wp' ), 'checkbox_disabled' );
 		} elseif ( in_array( $status, array( StoryStatus::Scheduled->value, StoryStatus::Processing->value ), true ) ) {
 			delete_post_meta( $post_id, '_zw_knabbel_story_state' );
 		}
@@ -351,7 +351,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 
 		// Delete story if it exists (sent or error state with story_id means it exists in Babbel).
 		if ( $story_id && in_array( $status, array( StoryStatus::Sent->value, StoryStatus::Error->value ), true ) ) {
-			push_story_delete( $post_id, $story_id, __( 'Story deleted (post unscheduled)', 'zw-knabbel-wp' ) );
+			push_story_delete( $post_id, $story_id, __( 'Story deleted (post unscheduled)', 'zw-knabbel-wp' ), 'post_unscheduled' );
 		} elseif ( in_array( $status, array( StoryStatus::Scheduled->value, StoryStatus::Processing->value ), true ) ) {
 			// Clear pending state if job was cancelled.
 			delete_post_meta( $post_id, '_zw_knabbel_story_state' );
@@ -382,7 +382,7 @@ function handle_trash_post( int $post_id ): void {
 	$story_id = (string) ( $state['story_id'] ?? '' );
 
 	if ( $story_id && StoryStatus::Sent->value === $status ) {
-		push_story_delete( $post_id, $story_id, __( 'Story deleted (post trashed)', 'zw-knabbel-wp' ) );
+		push_story_delete( $post_id, $story_id, __( 'Story deleted (post trashed)', 'zw-knabbel-wp' ), 'post_trashed' );
 	} elseif ( in_array( $status, array( StoryStatus::Scheduled->value, StoryStatus::Processing->value ), true ) ) {
 		// Clear pending state if job was cancelled.
 		delete_post_meta( $post_id, '_zw_knabbel_story_state' );
@@ -526,8 +526,9 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
  * @param int    $post_id         Post ID.
  * @param string $story_id        Babbel story ID.
  * @param string $success_message Translated message for the story state on success.
+ * @param string $log_context     Machine-readable context for failure logs.
  */
-function push_story_delete( int $post_id, string $story_id, string $success_message ): void {
+function push_story_delete( int $post_id, string $story_id, string $success_message, string $log_context ): void {
 	$result = babbel_delete_story( $story_id );
 	if ( $result['success'] ) {
 		update_story_state(
@@ -539,6 +540,18 @@ function push_story_delete( int $post_id, string $story_id, string $success_mess
 		);
 		return;
 	}
+
+	log(
+		'error',
+		'PostHooks',
+		'Failed to delete story in Babbel',
+		array(
+			'post_id'  => $post_id,
+			'story_id' => $story_id,
+			'context'  => $log_context,
+			'error'    => $result['message'],
+		)
+	);
 
 	update_story_state(
 		$post_id,

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -207,24 +207,7 @@ function handle_checkbox_change( int $post_id, bool $was_enabled, bool $is_enabl
 
 		// Delete from Babbel if story was sent.
 		if ( $story_id && StoryStatus::Sent->value === $status ) {
-			$result = babbel_delete_story( $story_id );
-			if ( $result['success'] ) {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Deleted->value,
-						'message' => __( 'Story deleted from Babbel', 'zw-knabbel-wp' ),
-					)
-				);
-			} else {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Error->value,
-						'message' => $result['message'],
-					)
-				);
-			}
+			push_story_delete( $post_id, $story_id, __( 'Story deleted from Babbel', 'zw-knabbel-wp' ) );
 		} elseif ( in_array( $status, array( StoryStatus::Scheduled->value, StoryStatus::Processing->value ), true ) ) {
 			delete_post_meta( $post_id, '_zw_knabbel_story_state' );
 		}
@@ -368,24 +351,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 
 		// Delete story if it exists (sent or error state with story_id means it exists in Babbel).
 		if ( $story_id && in_array( $status, array( StoryStatus::Sent->value, StoryStatus::Error->value ), true ) ) {
-			$result = babbel_delete_story( $story_id );
-			if ( $result['success'] ) {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Deleted->value,
-						'message' => __( 'Story deleted (post unscheduled)', 'zw-knabbel-wp' ),
-					)
-				);
-			} else {
-				update_story_state(
-					$post_id,
-					array(
-						'status'  => StoryStatus::Error->value,
-						'message' => $result['message'],
-					)
-				);
-			}
+			push_story_delete( $post_id, $story_id, __( 'Story deleted (post unscheduled)', 'zw-knabbel-wp' ) );
 		} elseif ( in_array( $status, array( StoryStatus::Scheduled->value, StoryStatus::Processing->value ), true ) ) {
 			// Clear pending state if job was cancelled.
 			delete_post_meta( $post_id, '_zw_knabbel_story_state' );
@@ -416,24 +382,7 @@ function handle_trash_post( int $post_id ): void {
 	$story_id = (string) ( $state['story_id'] ?? '' );
 
 	if ( $story_id && StoryStatus::Sent->value === $status ) {
-		$result = babbel_delete_story( $story_id );
-		if ( $result['success'] ) {
-			update_story_state(
-				$post_id,
-				array(
-					'status'  => StoryStatus::Deleted->value,
-					'message' => __( 'Story deleted (post trashed)', 'zw-knabbel-wp' ),
-				)
-			);
-		} else {
-			update_story_state(
-				$post_id,
-				array(
-					'status'  => StoryStatus::Error->value,
-					'message' => $result['message'],
-				)
-			);
-		}
+		push_story_delete( $post_id, $story_id, __( 'Story deleted (post trashed)', 'zw-knabbel-wp' ) );
 	} elseif ( in_array( $status, array( StoryStatus::Scheduled->value, StoryStatus::Processing->value ), true ) ) {
 		// Clear pending state if job was cancelled.
 		delete_post_meta( $post_id, '_zw_knabbel_story_state' );
@@ -567,6 +516,37 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
 			)
 		);
 	}
+}
+
+/**
+ * Deletes a story from Babbel and updates the local story state.
+ *
+ * @since 0.4.0
+ *
+ * @param int    $post_id         Post ID.
+ * @param string $story_id        Babbel story ID.
+ * @param string $success_message Translated message for the story state on success.
+ */
+function push_story_delete( int $post_id, string $story_id, string $success_message ): void {
+	$result = babbel_delete_story( $story_id );
+	if ( $result['success'] ) {
+		update_story_state(
+			$post_id,
+			array(
+				'status'  => StoryStatus::Deleted->value,
+				'message' => $success_message,
+			)
+		);
+		return;
+	}
+
+	update_story_state(
+		$post_id,
+		array(
+			'status'  => StoryStatus::Error->value,
+			'message' => $result['message'],
+		)
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

- add a shared `push_story_delete()` helper for Babbel delete result handling
- route checkbox, unschedule, and trash deletion paths through the helper
- delegate metabox checkbox transitions to the existing global `handle_checkbox_change()` handler
- preserve the existing success messages, status transitions, scheduling cancellation, nonce, and capability checks

Closes #25

## Testing

- `php -l includes/post-hooks.php`
- `php -l includes/admin/metabox.php`
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `npm run lint`
- `git diff --check`

## Manual verification guidance

- uncheck Radio News on a sent post and confirm the Babbel story is deleted
- move a scheduled post back to draft and confirm deletion
- trash a sent post and confirm deletion
- force a Babbel delete failure in each path and confirm the story state becomes `error` with the API message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized Babbel story deletion and post-state updates into a shared deletion helper, used for checkbox disabling, unscheduling behavior, and trashing flows.
  * Streamlined checkbox handling by delegating checkbox transitions to a common synchronization handler.
  * Kept existing user-facing success/error messaging behavior while standardizing how local story state is updated and how failures are logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->