### PR TITLE
fix: display recent admin errors

### DIFF
--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -38,12 +38,15 @@ function handle_clear_recent_errors(): void {
 	}
 
 	check_admin_referer( 'knabbel_clear_recent_errors' );
-	delete_option( 'knabbel_recent_errors' );
+
+	$missing_option = new \stdClass();
+	$stored_errors  = get_option( 'knabbel_recent_errors', $missing_option );
+	$errors_cleared = $missing_option === $stored_errors || delete_option( 'knabbel_recent_errors' );
 
 	$redirect_url = add_query_arg(
 		array(
 			'page'                   => 'zw-knabbel-wp-settings',
-			'knabbel_errors_cleared' => '1',
+			'knabbel_errors_cleared' => $errors_cleared ? '1' : '0',
 		),
 		admin_url( 'options-general.php' )
 	);
@@ -211,9 +214,16 @@ function settings_page(): void {
 	<div class="wrap knabbel-wp-admin">
 		<?php
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only confirmation after the nonce-protected clear action.
-		if ( isset( $_GET['knabbel_errors_cleared'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['knabbel_errors_cleared'] ) ) ) :
+		$clear_status = isset( $_GET['knabbel_errors_cleared'] ) ? sanitize_text_field( wp_unslash( $_GET['knabbel_errors_cleared'] ) ) : '';
+		if ( '1' === $clear_status ) :
 			?>
-			<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'Recent errors cleared.', 'zw-knabbel-wp' ); ?></p></div>
+			<div class="notice notice-success is-dismissible">
+				<p><?php esc_html_e( 'Recent errors cleared.', 'zw-knabbel-wp' ); ?></p>
+			</div>
+		<?php elseif ( '0' === $clear_status ) : ?>
+			<div class="notice notice-error is-dismissible">
+				<p><?php esc_html_e( 'Recent errors could not be cleared. Please try again.', 'zw-knabbel-wp' ); ?></p>
+			</div>
 		<?php endif; ?>
 		<!-- Page Header -->
 		<div class="knabbel-page-header">
@@ -273,9 +283,6 @@ function render_recent_errors(): void {
 		}
 	}
 
-	if ( empty( $recent_errors ) ) {
-		return;
-	}
 	?>
 	<div id="knabbel-recent-errors" class="knabbel-settings-card" style="margin-top: 24px;">
 		<div class="knabbel-card-title knabbel-articles-header">
@@ -294,25 +301,31 @@ function render_recent_errors(): void {
 					</tr>
 				</thead>
 				<tbody>
-					<?php foreach ( $recent_errors as $entry ) : ?>
-						<?php
-						$timestamp    = $entry['timestamp'];
-						$timestamp_ts = $timestamp ? strtotime( $timestamp . ' ' . wp_timezone_string() ) : false;
-						?>
+					<?php if ( empty( $recent_errors ) ) : ?>
 						<tr>
-							<td>
-								<?php
-								echo esc_html(
-									$timestamp_ts
-										? wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp_ts )
-										: $timestamp
-								);
-								?>
-							</td>
-							<td class="mono"><?php echo esc_html( $entry['component'] ); ?></td>
-							<td class="error-message"><?php echo esc_html( $entry['message'] ); ?></td>
+							<td colspan="3"><?php esc_html_e( 'No valid recent errors to display.', 'zw-knabbel-wp' ); ?></td>
 						</tr>
-					<?php endforeach; ?>
+					<?php else : ?>
+						<?php foreach ( $recent_errors as $entry ) : ?>
+							<?php
+							$timestamp    = $entry['timestamp'];
+							$timestamp_ts = $timestamp ? strtotime( $timestamp . ' ' . wp_timezone_string() ) : false;
+							?>
+							<tr>
+								<td>
+									<?php
+									echo esc_html(
+										$timestamp_ts
+											? wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp_ts )
+											: $timestamp
+									);
+									?>
+								</td>
+								<td class="mono"><?php echo esc_html( $entry['component'] ); ?></td>
+								<td class="error-message"><?php echo esc_html( $entry['message'] ); ?></td>
+							</tr>
+						<?php endforeach; ?>
+					<?php endif; ?>
 				</tbody>
 			</table>
 		</div>

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -24,6 +24,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 function settings_init(): void {
 	add_action( 'admin_menu', __NAMESPACE__ . '\\settings_add_admin_menu' );
 	add_action( 'admin_init', __NAMESPACE__ . '\\settings_register_settings' );
+	add_action( 'admin_post_knabbel_clear_recent_errors', __NAMESPACE__ . '\\handle_clear_recent_errors' );
+}
+
+/**
+ * Clears the rolling recent error list for an authorized administrator.
+ *
+ * @since 0.4.0
+ */
+function handle_clear_recent_errors(): void {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to perform this action.', 'zw-knabbel-wp' ) );
+	}
+
+	check_admin_referer( 'knabbel_clear_recent_errors' );
+	delete_option( 'knabbel_recent_errors' );
+
+	$redirect_url = add_query_arg(
+		array(
+			'page'                   => 'zw-knabbel-wp-settings',
+			'knabbel_errors_cleared' => '1',
+		),
+		admin_url( 'options-general.php' )
+	);
+
+	wp_safe_redirect( $redirect_url . '#knabbel-recent-errors' );
+	exit;
 }
 
 /**
@@ -183,6 +209,12 @@ function settings_page(): void {
 	$settings = get_option( 'knabbel_settings', array() );
 	?>
 	<div class="wrap knabbel-wp-admin">
+		<?php
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only confirmation after the nonce-protected clear action.
+		if ( isset( $_GET['knabbel_errors_cleared'] ) && '1' === sanitize_text_field( wp_unslash( $_GET['knabbel_errors_cleared'] ) ) ) :
+			?>
+			<div class="notice notice-success is-dismissible"><p><?php esc_html_e( 'Recent errors cleared.', 'zw-knabbel-wp' ); ?></p></div>
+		<?php endif; ?>
 		<!-- Page Header -->
 		<div class="knabbel-page-header">
 			<h1><?php esc_html_e( 'ZuidWest Knabbel', 'zw-knabbel-wp' ); ?></h1>
@@ -209,7 +241,98 @@ function settings_page(): void {
 		if ( debug_enabled() ) {
 			render_articles_overview();
 		}
+		render_recent_errors();
 		?>
+	</div>
+	<?php
+}
+
+/**
+ * Displays the rolling list of recent plugin errors.
+ *
+ * Only top-level fields are rendered. Stored context remains intentionally
+ * hidden so nested API data can never become an unfiltered admin output path.
+ *
+ * @since 0.4.0
+ */
+function render_recent_errors(): void {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	$stored_errors = get_option( 'knabbel_recent_errors', array() );
+	if ( ! is_array( $stored_errors ) || empty( $stored_errors ) ) {
+		return;
+	}
+
+	$recent_errors = array();
+	foreach ( array_reverse( $stored_errors ) as $entry ) {
+		if ( ! is_array( $entry ) || ! isset( $entry['component'], $entry['message'] ) ) {
+			continue;
+		}
+		if ( ! is_scalar( $entry['component'] ) || ! is_scalar( $entry['message'] ) ) {
+			continue;
+		}
+
+		$recent_errors[] = array(
+			'timestamp' => isset( $entry['timestamp'] ) && is_scalar( $entry['timestamp'] ) ? (string) $entry['timestamp'] : '',
+			'component' => (string) $entry['component'],
+			'message'   => (string) $entry['message'],
+		);
+	}
+
+	if ( empty( $recent_errors ) ) {
+		return;
+	}
+	?>
+	<div id="knabbel-recent-errors" class="knabbel-settings-card" style="margin-top: 24px;">
+		<div class="knabbel-card-title knabbel-articles-header">
+			<div class="header-left">
+				<span class="dashicons dashicons-warning card-icon"></span>
+				<h2><?php esc_html_e( 'Recent Errors', 'zw-knabbel-wp' ); ?></h2>
+			</div>
+		</div>
+		<div class="knabbel-card-content" style="padding: 0;">
+			<table class="knabbel-articles-table">
+				<thead>
+					<tr>
+						<th scope="col"><?php esc_html_e( 'Time', 'zw-knabbel-wp' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Component', 'zw-knabbel-wp' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Message', 'zw-knabbel-wp' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ( $recent_errors as $entry ) : ?>
+						<?php
+						$timestamp    = $entry['timestamp'];
+						$timestamp_ts = $timestamp ? strtotime( $timestamp . ' ' . wp_timezone_string() ) : false;
+						?>
+						<tr>
+							<td>
+								<?php
+								echo esc_html(
+									$timestamp_ts
+										? wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp_ts )
+										: $timestamp
+								);
+								?>
+							</td>
+							<td class="mono"><?php echo esc_html( $entry['component'] ); ?></td>
+							<td class="error-message"><?php echo esc_html( $entry['message'] ); ?></td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		</div>
+		<div class="knabbel-articles-footer">
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="knabbel_clear_recent_errors" />
+				<?php wp_nonce_field( 'knabbel_clear_recent_errors' ); ?>
+				<button type="submit" class="knabbel-btn knabbel-btn-secondary">
+					<?php esc_html_e( 'Clear Errors', 'zw-knabbel-wp' ); ?>
+				</button>
+			</form>
+		</div>
 	</div>
 	<?php
 }

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -267,18 +267,10 @@ function render_recent_errors(): void {
 
 	$recent_errors = array();
 	foreach ( array_reverse( $stored_errors ) as $entry ) {
-		if ( ! is_array( $entry ) || ! isset( $entry['component'], $entry['message'] ) ) {
-			continue;
+		$normalized_entry = normalize_recent_error_entry( $entry );
+		if ( null !== $normalized_entry ) {
+			$recent_errors[] = $normalized_entry;
 		}
-		if ( ! is_scalar( $entry['component'] ) || ! is_scalar( $entry['message'] ) ) {
-			continue;
-		}
-
-		$recent_errors[] = array(
-			'timestamp' => isset( $entry['timestamp'] ) && is_scalar( $entry['timestamp'] ) ? (string) $entry['timestamp'] : '',
-			'component' => (string) $entry['component'],
-			'message'   => (string) $entry['message'],
-		);
 	}
 
 	if ( empty( $recent_errors ) ) {
@@ -335,6 +327,28 @@ function render_recent_errors(): void {
 		</div>
 	</div>
 	<?php
+}
+
+/**
+ * Normalizes a stored error entry into the safe render shape.
+ *
+ * @since 0.4.0
+ * @param mixed $entry Raw entry from the knabbel_recent_errors option.
+ * @return array{timestamp: string, component: string, message: string}|null Normalized entry, or null when invalid.
+ */
+function normalize_recent_error_entry( mixed $entry ): ?array {
+	if ( ! is_array( $entry ) || ! isset( $entry['component'], $entry['message'] ) ) {
+		return null;
+	}
+	if ( ! is_scalar( $entry['component'] ) || ! is_scalar( $entry['message'] ) ) {
+		return null;
+	}
+
+	return array(
+		'timestamp' => isset( $entry['timestamp'] ) && is_scalar( $entry['timestamp'] ) ? (string) $entry['timestamp'] : '',
+		'component' => (string) $entry['component'],
+		'message'   => (string) $entry['message'],
+	);
 }
 
 /**

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -2,22 +2,22 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: ZuidWest Knabbel 0.3.0\n"
+"Project-Id-Version: ZuidWest Knabbel 0.4.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-03-29T21:03:57+00:00\n"
+"POT-Creation-Date: 2026-07-19T11:34:48+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zw-knabbel-wp\n"
 
 #. Plugin Name of the plugin
 #: zw-knabbel-wp.php
-#: includes/admin/settings.php:37
-#: includes/admin/settings.php:188
+#: includes/admin/settings.php:63
+#: includes/admin/settings.php:220
 msgid "ZuidWest Knabbel"
 msgstr ""
 
@@ -51,28 +51,28 @@ msgid "Knabbel Status"
 msgstr ""
 
 #: includes/admin/metabox.php:137
-#: includes/admin/settings.php:469
-#: includes/admin/settings.php:644
+#: includes/admin/settings.php:592
+#: includes/admin/settings.php:767
 msgid "Status"
 msgstr ""
 
 #: includes/admin/metabox.php:141
-#: includes/admin/settings.php:589
+#: includes/admin/settings.php:712
 msgid "Scheduled"
 msgstr ""
 
 #: includes/admin/metabox.php:142
-#: includes/admin/settings.php:590
+#: includes/admin/settings.php:713
 msgid "Processing"
 msgstr ""
 
 #: includes/admin/metabox.php:143
-#: includes/admin/settings.php:591
+#: includes/admin/settings.php:714
 msgid "Sent"
 msgstr ""
 
 #: includes/admin/metabox.php:144
-#: includes/admin/settings.php:592
+#: includes/admin/settings.php:715
 msgid "Error"
 msgstr ""
 
@@ -97,8 +97,9 @@ msgid "Scheduled:"
 msgstr ""
 
 #: includes/admin/metabox.php:178
-#: includes/admin/settings.php:665
-#: includes/admin/settings.php:670
+#: includes/admin/settings.php:301
+#: includes/admin/settings.php:788
+#: includes/admin/settings.php:793
 msgid "Message"
 msgstr ""
 
@@ -107,208 +108,232 @@ msgstr ""
 msgid "Story deleted from Babbel"
 msgstr ""
 
-#: includes/admin/settings.php:36
+#: includes/admin/settings.php:37
+msgid "You do not have sufficient permissions to perform this action."
+msgstr ""
+
+#: includes/admin/settings.php:62
 msgid "ZuidWest Knabbel Settings"
 msgstr ""
 
-#: includes/admin/settings.php:152
+#: includes/admin/settings.php:178
 msgid "You do not have sufficient permissions to view this page."
 msgstr ""
 
-#: includes/admin/settings.php:177
+#: includes/admin/settings.php:203
 msgid "Testing..."
 msgstr ""
 
-#: includes/admin/settings.php:178
-#: includes/admin/settings.php:293
+#: includes/admin/settings.php:204
+#: includes/admin/settings.php:416
 msgid "Test API Connection"
 msgstr ""
 
-#: includes/admin/settings.php:179
+#: includes/admin/settings.php:205
 msgid "An error occurred"
 msgstr ""
 
-#: includes/admin/settings.php:190
+#: includes/admin/settings.php:216
+msgid "Recent errors cleared."
+msgstr ""
+
+#: includes/admin/settings.php:222
 msgid "Wijzigingen opslaan"
 msgstr ""
 
-#: includes/admin/settings.php:228
+#: includes/admin/settings.php:292
+msgid "Recent Errors"
+msgstr ""
+
+#: includes/admin/settings.php:299
+msgid "Time"
+msgstr ""
+
+#: includes/admin/settings.php:300
+msgid "Component"
+msgstr ""
+
+#: includes/admin/settings.php:332
+msgid "Clear Errors"
+msgstr ""
+
+#: includes/admin/settings.php:351
 msgid "Babbel API"
 msgstr ""
 
-#: includes/admin/settings.php:232
+#: includes/admin/settings.php:355
 msgid "Configure the Babbel API settings."
 msgstr ""
 
-#: includes/admin/settings.php:237
+#: includes/admin/settings.php:360
 msgid "Babbel API Base URL"
 msgstr ""
 
-#: includes/admin/settings.php:246
+#: includes/admin/settings.php:369
 msgid "The base URL of the Babbel API (without trailing slash)."
 msgstr ""
 
-#: includes/admin/settings.php:253
+#: includes/admin/settings.php:376
 msgid "Babbel API Username"
 msgstr ""
 
-#: includes/admin/settings.php:260
+#: includes/admin/settings.php:383
 msgid "username"
 msgstr ""
 
-#: includes/admin/settings.php:265
+#: includes/admin/settings.php:388
 msgid "Babbel API Password"
 msgstr ""
 
-#: includes/admin/settings.php:283
+#: includes/admin/settings.php:406
 msgid "Enable Debug Mode"
 msgstr ""
 
-#: includes/admin/settings.php:287
+#: includes/admin/settings.php:410
 msgid "Show debug information and status in the sidebar. Only enable for troubleshooting."
 msgstr ""
 
-#: includes/admin/settings.php:313
+#: includes/admin/settings.php:436
 msgid "OpenAI"
 msgstr ""
 
-#: includes/admin/settings.php:317
+#: includes/admin/settings.php:440
 msgid "Configure OpenAI for generating speech text."
 msgstr ""
 
-#: includes/admin/settings.php:322
+#: includes/admin/settings.php:445
 msgid "OpenAI API Key"
 msgstr ""
 
 #. translators: %s: URL to OpenAI API keys page
-#: includes/admin/settings.php:334
+#: includes/admin/settings.php:457
 #, php-format
 msgid "Your OpenAI API key. Available at %s"
 msgstr ""
 
-#: includes/admin/settings.php:344
+#: includes/admin/settings.php:467
 msgid "OpenAI Model"
 msgstr ""
 
-#: includes/admin/settings.php:352
+#: includes/admin/settings.php:475
 msgid "The OpenAI model for text generation (e.g., gpt-4.1-mini, gpt-4o-mini, gpt-4o)."
 msgstr ""
 
-#: includes/admin/settings.php:358
+#: includes/admin/settings.php:481
 msgid "Few-shot Examples"
 msgstr ""
 
-#: includes/admin/settings.php:368
+#: includes/admin/settings.php:491
 msgid "Number of editor-corrected examples to include in the speech prompt (0 to disable, max 20). Synced nightly from Babbel."
 msgstr ""
 
-#: includes/admin/settings.php:392
+#: includes/admin/settings.php:515
 msgid "AI Prompts"
 msgstr ""
 
-#: includes/admin/settings.php:396
+#: includes/admin/settings.php:519
 msgid "Customize the AI prompt for generating speech text."
 msgstr ""
 
-#: includes/admin/settings.php:401
+#: includes/admin/settings.php:524
 msgid "Speech Text Generation Prompt"
 msgstr ""
 
-#: includes/admin/settings.php:409
+#: includes/admin/settings.php:532
 msgid "Prompt for converting to radio-friendly speech text. Leave empty for default prompt."
 msgstr ""
 
-#: includes/admin/settings.php:425
+#: includes/admin/settings.php:548
 msgid "Sun"
 msgstr ""
 
-#: includes/admin/settings.php:426
+#: includes/admin/settings.php:549
 msgid "Mon"
 msgstr ""
 
-#: includes/admin/settings.php:427
+#: includes/admin/settings.php:550
 msgid "Tue"
 msgstr ""
 
-#: includes/admin/settings.php:428
+#: includes/admin/settings.php:551
 msgid "Wed"
 msgstr ""
 
-#: includes/admin/settings.php:429
+#: includes/admin/settings.php:552
 msgid "Thu"
 msgstr ""
 
-#: includes/admin/settings.php:430
+#: includes/admin/settings.php:553
 msgid "Fri"
 msgstr ""
 
-#: includes/admin/settings.php:431
+#: includes/admin/settings.php:554
 msgid "Sat"
 msgstr ""
 
-#: includes/admin/settings.php:438
+#: includes/admin/settings.php:561
 msgid "Story Defaults"
 msgstr ""
 
-#: includes/admin/settings.php:443
+#: includes/admin/settings.php:566
 msgid "Start Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:451
+#: includes/admin/settings.php:574
 msgid "Number of days from publication for start date."
 msgstr ""
 
-#: includes/admin/settings.php:456
+#: includes/admin/settings.php:579
 msgid "End Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:464
+#: includes/admin/settings.php:587
 msgid "Number of days from publication for end date."
 msgstr ""
 
-#: includes/admin/settings.php:478
+#: includes/admin/settings.php:601
 msgid "Active"
 msgstr ""
 
-#: includes/admin/settings.php:483
+#: includes/admin/settings.php:606
 msgid "Days"
 msgstr ""
 
-#: includes/admin/settings.php:501
+#: includes/admin/settings.php:624
 msgid "Which days the story may be broadcast."
 msgstr ""
 
-#: includes/admin/settings.php:615
+#: includes/admin/settings.php:738
 msgid "Knabbel Story Debug Overview"
 msgstr ""
 
-#: includes/admin/settings.php:629
+#: includes/admin/settings.php:752
 msgid "Show"
 msgstr ""
 
-#: includes/admin/settings.php:635
+#: includes/admin/settings.php:758
 msgid "Article"
 msgstr ""
 
-#: includes/admin/settings.php:653
+#: includes/admin/settings.php:776
 msgid "Last status change"
 msgstr ""
 
-#: includes/admin/settings.php:660
-#: includes/admin/settings.php:675
+#: includes/admin/settings.php:783
+#: includes/admin/settings.php:798
 msgid "Babbel ID"
 msgstr ""
 
-#: includes/admin/settings.php:671
-#: zw-knabbel-wp.php:563
+#: includes/admin/settings.php:794
+#: zw-knabbel-wp.php:404
 msgid "Story is being processed..."
 msgstr ""
 
-#: includes/admin/settings.php:688
+#: includes/admin/settings.php:811
 msgid "Retry"
 msgstr ""
 
-#: includes/admin/settings.php:693
+#: includes/admin/settings.php:816
 msgid "Refresh"
 msgstr ""
 
@@ -332,23 +357,23 @@ msgid "Could not encode story data"
 msgstr ""
 
 #: includes/babbel-api.php:222
-#: includes/babbel-api.php:442
-#: includes/babbel-api.php:517
-#: includes/babbel-api.php:616
+#: includes/babbel-api.php:443
+#: includes/babbel-api.php:518
+#: includes/babbel-api.php:617
 msgid "API connection failed: "
 msgstr ""
 
 #. translators: %1$d is the HTTP status code, %2$s is the response body.
 #: includes/babbel-api.php:244
-#: includes/babbel-api.php:464
-#: includes/babbel-api.php:540
-#: includes/babbel-api.php:638
+#: includes/babbel-api.php:465
+#: includes/babbel-api.php:541
+#: includes/babbel-api.php:639
 #, php-format
 msgid "API error: HTTP %1$d - %2$s"
 msgstr ""
 
 #: includes/babbel-api.php:263
-#: includes/babbel-api.php:731
+#: includes/babbel-api.php:732
 msgid "Invalid API response"
 msgstr ""
 
@@ -361,7 +386,7 @@ msgid "No story ID received from API"
 msgstr ""
 
 #: includes/babbel-api.php:316
-#: zw-knabbel-wp.php:618
+#: zw-knabbel-wp.php:459
 msgid "Story created successfully"
 msgstr ""
 
@@ -385,95 +410,94 @@ msgstr ""
 msgid "Unexpected response: HTTP %d"
 msgstr ""
 
-#: includes/babbel-api.php:401
+#: includes/babbel-api.php:402
 msgid "No data to update"
 msgstr ""
 
-#: includes/babbel-api.php:410
-#: includes/babbel-api.php:416
+#: includes/babbel-api.php:411
+#: includes/babbel-api.php:417
 msgid "Could not encode update data"
 msgstr ""
 
-#: includes/babbel-api.php:480
+#: includes/babbel-api.php:481
 msgid "Story updated successfully"
 msgstr ""
 
-#: includes/babbel-api.php:556
+#: includes/babbel-api.php:557
 msgid "Story deleted successfully"
 msgstr ""
 
-#: includes/babbel-api.php:584
-#: includes/babbel-api.php:590
+#: includes/babbel-api.php:585
+#: includes/babbel-api.php:591
 msgid "Could not encode restore data"
 msgstr ""
 
-#: includes/babbel-api.php:654
+#: includes/babbel-api.php:655
 msgid "Story restored successfully"
 msgstr ""
 
-#: includes/babbel-api.php:672
+#: includes/babbel-api.php:673
 msgid "Babbel API base URL not configured"
 msgstr ""
 
 #. translators: %d is the HTTP status code.
-#: includes/babbel-api.php:718
+#: includes/babbel-api.php:719
 #, php-format
 msgid "API error: HTTP %d"
 msgstr ""
 
-#: includes/post-hooks.php:328
+#: includes/post-hooks.php:317
 msgid "Story updated (post published)"
 msgstr ""
 
-#: includes/post-hooks.php:390
-#: includes/post-hooks.php:435
+#: includes/post-hooks.php:352
 msgid "Story updated in Babbel"
 msgstr ""
 
-#: includes/post-hooks.php:472
+#: includes/post-hooks.php:377
 msgid "Story deleted (post unscheduled)"
 msgstr ""
 
-#: includes/post-hooks.php:520
+#: includes/post-hooks.php:425
 msgid "Story deleted (post trashed)"
 msgstr ""
 
-#: includes/post-hooks.php:597
+#: includes/post-hooks.php:502
 msgid "Story restored in Babbel"
 msgstr ""
 
-#: includes/post-hooks.php:616
+#: includes/post-hooks.php:521
 msgid "Story restored, but title sync failed"
 msgstr ""
 
-#: includes/post-hooks.php:640
+#: includes/post-hooks.php:641
 msgid "Processing already scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:659
+#: includes/post-hooks.php:660
 msgid "Processing scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:667
+#: includes/post-hooks.php:668
 msgid "Could not schedule action"
 msgstr ""
 
-#: zw-knabbel-wp.php:488
+#: zw-knabbel-wp.php:329
 msgid "Insufficient permissions"
 msgstr ""
 
-#: zw-knabbel-wp.php:527
+#: zw-knabbel-wp.php:368
 msgid "Already sent — skipping"
 msgstr ""
 
-#: zw-knabbel-wp.php:539
+#: zw-knabbel-wp.php:380
 msgid "Post not found"
 msgstr ""
 
-#: zw-knabbel-wp.php:552
+#: zw-knabbel-wp.php:393
 msgid "Send to Babbel is disabled for this post"
 msgstr ""
 
-#: zw-knabbel-wp.php:579
+#: zw-knabbel-wp.php:420
 msgid "Could not generate speech text"
 msgstr ""

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-19T11:34:48+00:00\n"
+"POT-Creation-Date: 2026-07-19T12:59:40+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zw-knabbel-wp\n"
@@ -42,70 +42,65 @@ msgid "https://www.zuidwesttv.nl"
 msgstr ""
 
 #: includes/admin/metabox.php:70
-#: includes/admin/metabox.php:115
+#: includes/admin/metabox.php:113
 msgid "Radio News"
 msgstr ""
 
-#: includes/admin/metabox.php:92
+#: includes/admin/metabox.php:90
 msgid "Knabbel Status"
 msgstr ""
 
-#: includes/admin/metabox.php:137
-#: includes/admin/settings.php:592
-#: includes/admin/settings.php:767
+#: includes/admin/metabox.php:135
+#: includes/admin/settings.php:606
+#: includes/admin/settings.php:781
 msgid "Status"
 msgstr ""
 
-#: includes/admin/metabox.php:141
-#: includes/admin/settings.php:712
+#: includes/admin/metabox.php:139
+#: includes/admin/settings.php:726
 msgid "Scheduled"
 msgstr ""
 
-#: includes/admin/metabox.php:142
-#: includes/admin/settings.php:713
+#: includes/admin/metabox.php:140
+#: includes/admin/settings.php:727
 msgid "Processing"
 msgstr ""
 
-#: includes/admin/metabox.php:143
-#: includes/admin/settings.php:714
+#: includes/admin/metabox.php:141
+#: includes/admin/settings.php:728
 msgid "Sent"
 msgstr ""
 
-#: includes/admin/metabox.php:144
-#: includes/admin/settings.php:715
+#: includes/admin/metabox.php:142
+#: includes/admin/settings.php:729
 msgid "Error"
 msgstr ""
 
-#: includes/admin/metabox.php:145
+#: includes/admin/metabox.php:143
 msgid "Deleted"
 msgstr ""
 
-#: includes/admin/metabox.php:147
+#: includes/admin/metabox.php:145
 msgid "—"
 msgstr ""
 
-#: includes/admin/metabox.php:153
+#: includes/admin/metabox.php:151
 msgid "Last status change:"
 msgstr ""
 
-#: includes/admin/metabox.php:163
+#: includes/admin/metabox.php:161
 msgid "Story ID"
 msgstr ""
 
-#: includes/admin/metabox.php:169
+#: includes/admin/metabox.php:167
 msgid "Scheduled:"
 msgstr ""
 
-#: includes/admin/metabox.php:178
-#: includes/admin/settings.php:301
-#: includes/admin/settings.php:788
-#: includes/admin/settings.php:793
+#: includes/admin/metabox.php:176
+#: includes/admin/settings.php:293
+#: includes/admin/settings.php:802
+#: includes/admin/settings.php:807
 msgid "Message"
-msgstr ""
-
-#: includes/admin/metabox.php:254
-#: includes/post-hooks.php:216
-msgid "Story deleted from Babbel"
 msgstr ""
 
 #: includes/admin/settings.php:37
@@ -125,7 +120,7 @@ msgid "Testing..."
 msgstr ""
 
 #: includes/admin/settings.php:204
-#: includes/admin/settings.php:416
+#: includes/admin/settings.php:430
 msgid "Test API Connection"
 msgstr ""
 
@@ -141,199 +136,199 @@ msgstr ""
 msgid "Wijzigingen opslaan"
 msgstr ""
 
-#: includes/admin/settings.php:292
+#: includes/admin/settings.php:284
 msgid "Recent Errors"
 msgstr ""
 
-#: includes/admin/settings.php:299
+#: includes/admin/settings.php:291
 msgid "Time"
 msgstr ""
 
-#: includes/admin/settings.php:300
+#: includes/admin/settings.php:292
 msgid "Component"
 msgstr ""
 
-#: includes/admin/settings.php:332
+#: includes/admin/settings.php:324
 msgid "Clear Errors"
 msgstr ""
 
-#: includes/admin/settings.php:351
+#: includes/admin/settings.php:365
 msgid "Babbel API"
 msgstr ""
 
-#: includes/admin/settings.php:355
+#: includes/admin/settings.php:369
 msgid "Configure the Babbel API settings."
 msgstr ""
 
-#: includes/admin/settings.php:360
+#: includes/admin/settings.php:374
 msgid "Babbel API Base URL"
 msgstr ""
 
-#: includes/admin/settings.php:369
+#: includes/admin/settings.php:383
 msgid "The base URL of the Babbel API (without trailing slash)."
 msgstr ""
 
-#: includes/admin/settings.php:376
+#: includes/admin/settings.php:390
 msgid "Babbel API Username"
 msgstr ""
 
-#: includes/admin/settings.php:383
+#: includes/admin/settings.php:397
 msgid "username"
 msgstr ""
 
-#: includes/admin/settings.php:388
+#: includes/admin/settings.php:402
 msgid "Babbel API Password"
 msgstr ""
 
-#: includes/admin/settings.php:406
+#: includes/admin/settings.php:420
 msgid "Enable Debug Mode"
 msgstr ""
 
-#: includes/admin/settings.php:410
+#: includes/admin/settings.php:424
 msgid "Show debug information and status in the sidebar. Only enable for troubleshooting."
 msgstr ""
 
-#: includes/admin/settings.php:436
+#: includes/admin/settings.php:450
 msgid "OpenAI"
 msgstr ""
 
-#: includes/admin/settings.php:440
+#: includes/admin/settings.php:454
 msgid "Configure OpenAI for generating speech text."
 msgstr ""
 
-#: includes/admin/settings.php:445
+#: includes/admin/settings.php:459
 msgid "OpenAI API Key"
 msgstr ""
 
 #. translators: %s: URL to OpenAI API keys page
-#: includes/admin/settings.php:457
+#: includes/admin/settings.php:471
 #, php-format
 msgid "Your OpenAI API key. Available at %s"
 msgstr ""
 
-#: includes/admin/settings.php:467
+#: includes/admin/settings.php:481
 msgid "OpenAI Model"
 msgstr ""
 
-#: includes/admin/settings.php:475
+#: includes/admin/settings.php:489
 msgid "The OpenAI model for text generation (e.g., gpt-4.1-mini, gpt-4o-mini, gpt-4o)."
 msgstr ""
 
-#: includes/admin/settings.php:481
+#: includes/admin/settings.php:495
 msgid "Few-shot Examples"
 msgstr ""
 
-#: includes/admin/settings.php:491
+#: includes/admin/settings.php:505
 msgid "Number of editor-corrected examples to include in the speech prompt (0 to disable, max 20). Synced nightly from Babbel."
 msgstr ""
 
-#: includes/admin/settings.php:515
+#: includes/admin/settings.php:529
 msgid "AI Prompts"
 msgstr ""
 
-#: includes/admin/settings.php:519
+#: includes/admin/settings.php:533
 msgid "Customize the AI prompt for generating speech text."
 msgstr ""
 
-#: includes/admin/settings.php:524
+#: includes/admin/settings.php:538
 msgid "Speech Text Generation Prompt"
 msgstr ""
 
-#: includes/admin/settings.php:532
+#: includes/admin/settings.php:546
 msgid "Prompt for converting to radio-friendly speech text. Leave empty for default prompt."
 msgstr ""
 
-#: includes/admin/settings.php:548
+#: includes/admin/settings.php:562
 msgid "Sun"
 msgstr ""
 
-#: includes/admin/settings.php:549
+#: includes/admin/settings.php:563
 msgid "Mon"
 msgstr ""
 
-#: includes/admin/settings.php:550
+#: includes/admin/settings.php:564
 msgid "Tue"
 msgstr ""
 
-#: includes/admin/settings.php:551
+#: includes/admin/settings.php:565
 msgid "Wed"
 msgstr ""
 
-#: includes/admin/settings.php:552
+#: includes/admin/settings.php:566
 msgid "Thu"
 msgstr ""
 
-#: includes/admin/settings.php:553
+#: includes/admin/settings.php:567
 msgid "Fri"
 msgstr ""
 
-#: includes/admin/settings.php:554
+#: includes/admin/settings.php:568
 msgid "Sat"
 msgstr ""
 
-#: includes/admin/settings.php:561
+#: includes/admin/settings.php:575
 msgid "Story Defaults"
 msgstr ""
 
-#: includes/admin/settings.php:566
+#: includes/admin/settings.php:580
 msgid "Start Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:574
+#: includes/admin/settings.php:588
 msgid "Number of days from publication for start date."
 msgstr ""
 
-#: includes/admin/settings.php:579
+#: includes/admin/settings.php:593
 msgid "End Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:587
+#: includes/admin/settings.php:601
 msgid "Number of days from publication for end date."
 msgstr ""
 
-#: includes/admin/settings.php:601
+#: includes/admin/settings.php:615
 msgid "Active"
 msgstr ""
 
-#: includes/admin/settings.php:606
+#: includes/admin/settings.php:620
 msgid "Days"
 msgstr ""
 
-#: includes/admin/settings.php:624
+#: includes/admin/settings.php:638
 msgid "Which days the story may be broadcast."
 msgstr ""
 
-#: includes/admin/settings.php:738
+#: includes/admin/settings.php:752
 msgid "Knabbel Story Debug Overview"
 msgstr ""
 
-#: includes/admin/settings.php:752
+#: includes/admin/settings.php:766
 msgid "Show"
 msgstr ""
 
-#: includes/admin/settings.php:758
+#: includes/admin/settings.php:772
 msgid "Article"
 msgstr ""
 
-#: includes/admin/settings.php:776
+#: includes/admin/settings.php:790
 msgid "Last status change"
 msgstr ""
 
-#: includes/admin/settings.php:783
-#: includes/admin/settings.php:798
+#: includes/admin/settings.php:797
+#: includes/admin/settings.php:812
 msgid "Babbel ID"
 msgstr ""
 
-#: includes/admin/settings.php:794
-#: zw-knabbel-wp.php:404
+#: includes/admin/settings.php:808
+#: zw-knabbel-wp.php:632
 msgid "Story is being processed..."
 msgstr ""
 
-#: includes/admin/settings.php:811
+#: includes/admin/settings.php:825
 msgid "Retry"
 msgstr ""
 
-#: includes/admin/settings.php:816
+#: includes/admin/settings.php:830
 msgid "Refresh"
 msgstr ""
 
@@ -386,7 +381,7 @@ msgid "No story ID received from API"
 msgstr ""
 
 #: includes/babbel-api.php:316
-#: zw-knabbel-wp.php:459
+#: zw-knabbel-wp.php:687
 msgid "Story created successfully"
 msgstr ""
 
@@ -446,58 +441,62 @@ msgstr ""
 msgid "API error: HTTP %d"
 msgstr ""
 
-#: includes/post-hooks.php:317
+#: includes/post-hooks.php:210
+msgid "Story deleted from Babbel"
+msgstr ""
+
+#: includes/post-hooks.php:300
 msgid "Story updated (post published)"
 msgstr ""
 
-#: includes/post-hooks.php:352
+#: includes/post-hooks.php:335
 msgid "Story updated in Babbel"
 msgstr ""
 
-#: includes/post-hooks.php:377
+#: includes/post-hooks.php:354
 msgid "Story deleted (post unscheduled)"
 msgstr ""
 
-#: includes/post-hooks.php:425
+#: includes/post-hooks.php:385
 msgid "Story deleted (post trashed)"
 msgstr ""
 
-#: includes/post-hooks.php:502
+#: includes/post-hooks.php:451
 msgid "Story restored in Babbel"
 msgstr ""
 
-#: includes/post-hooks.php:521
+#: includes/post-hooks.php:470
 msgid "Story restored, but title sync failed"
 msgstr ""
 
-#: includes/post-hooks.php:641
+#: includes/post-hooks.php:634
 msgid "Processing already scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:660
+#: includes/post-hooks.php:653
 msgid "Processing scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:668
+#: includes/post-hooks.php:661
 msgid "Could not schedule action"
 msgstr ""
 
-#: zw-knabbel-wp.php:329
+#: zw-knabbel-wp.php:557
 msgid "Insufficient permissions"
 msgstr ""
 
-#: zw-knabbel-wp.php:368
+#: zw-knabbel-wp.php:596
 msgid "Already sent — skipping"
 msgstr ""
 
-#: zw-knabbel-wp.php:380
+#: zw-knabbel-wp.php:608
 msgid "Post not found"
 msgstr ""
 
-#: zw-knabbel-wp.php:393
+#: zw-knabbel-wp.php:621
 msgid "Send to Babbel is disabled for this post"
 msgstr ""
 
-#: zw-knabbel-wp.php:420
+#: zw-knabbel-wp.php:648
 msgid "Could not generate speech text"
 msgstr ""

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -9,15 +9,15 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-19T12:59:40+00:00\n"
+"POT-Creation-Date: 2026-07-19T13:04:56+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zw-knabbel-wp\n"
 
 #. Plugin Name of the plugin
 #: zw-knabbel-wp.php
-#: includes/admin/settings.php:63
-#: includes/admin/settings.php:220
+#: includes/admin/settings.php:66
+#: includes/admin/settings.php:230
 msgid "ZuidWest Knabbel"
 msgstr ""
 
@@ -51,28 +51,28 @@ msgid "Knabbel Status"
 msgstr ""
 
 #: includes/admin/metabox.php:135
-#: includes/admin/settings.php:606
-#: includes/admin/settings.php:781
+#: includes/admin/settings.php:619
+#: includes/admin/settings.php:794
 msgid "Status"
 msgstr ""
 
 #: includes/admin/metabox.php:139
-#: includes/admin/settings.php:726
+#: includes/admin/settings.php:739
 msgid "Scheduled"
 msgstr ""
 
 #: includes/admin/metabox.php:140
-#: includes/admin/settings.php:727
+#: includes/admin/settings.php:740
 msgid "Processing"
 msgstr ""
 
 #: includes/admin/metabox.php:141
-#: includes/admin/settings.php:728
+#: includes/admin/settings.php:741
 msgid "Sent"
 msgstr ""
 
 #: includes/admin/metabox.php:142
-#: includes/admin/settings.php:729
+#: includes/admin/settings.php:742
 msgid "Error"
 msgstr ""
 
@@ -97,9 +97,9 @@ msgid "Scheduled:"
 msgstr ""
 
 #: includes/admin/metabox.php:176
-#: includes/admin/settings.php:293
-#: includes/admin/settings.php:802
-#: includes/admin/settings.php:807
+#: includes/admin/settings.php:300
+#: includes/admin/settings.php:815
+#: includes/admin/settings.php:820
 msgid "Message"
 msgstr ""
 
@@ -107,228 +107,236 @@ msgstr ""
 msgid "You do not have sufficient permissions to perform this action."
 msgstr ""
 
-#: includes/admin/settings.php:62
+#: includes/admin/settings.php:65
 msgid "ZuidWest Knabbel Settings"
 msgstr ""
 
-#: includes/admin/settings.php:178
+#: includes/admin/settings.php:181
 msgid "You do not have sufficient permissions to view this page."
 msgstr ""
 
-#: includes/admin/settings.php:203
+#: includes/admin/settings.php:206
 msgid "Testing..."
 msgstr ""
 
-#: includes/admin/settings.php:204
-#: includes/admin/settings.php:430
+#: includes/admin/settings.php:207
+#: includes/admin/settings.php:443
 msgid "Test API Connection"
 msgstr ""
 
-#: includes/admin/settings.php:205
+#: includes/admin/settings.php:208
 msgid "An error occurred"
 msgstr ""
 
-#: includes/admin/settings.php:216
+#: includes/admin/settings.php:221
 msgid "Recent errors cleared."
 msgstr ""
 
-#: includes/admin/settings.php:222
+#: includes/admin/settings.php:225
+msgid "Recent errors could not be cleared. Please try again."
+msgstr ""
+
+#: includes/admin/settings.php:232
 msgid "Wijzigingen opslaan"
 msgstr ""
 
-#: includes/admin/settings.php:284
+#: includes/admin/settings.php:291
 msgid "Recent Errors"
 msgstr ""
 
-#: includes/admin/settings.php:291
+#: includes/admin/settings.php:298
 msgid "Time"
 msgstr ""
 
-#: includes/admin/settings.php:292
+#: includes/admin/settings.php:299
 msgid "Component"
 msgstr ""
 
-#: includes/admin/settings.php:324
+#: includes/admin/settings.php:306
+msgid "No valid recent errors to display."
+msgstr ""
+
+#: includes/admin/settings.php:337
 msgid "Clear Errors"
 msgstr ""
 
-#: includes/admin/settings.php:365
+#: includes/admin/settings.php:378
 msgid "Babbel API"
 msgstr ""
 
-#: includes/admin/settings.php:369
+#: includes/admin/settings.php:382
 msgid "Configure the Babbel API settings."
 msgstr ""
 
-#: includes/admin/settings.php:374
+#: includes/admin/settings.php:387
 msgid "Babbel API Base URL"
 msgstr ""
 
-#: includes/admin/settings.php:383
+#: includes/admin/settings.php:396
 msgid "The base URL of the Babbel API (without trailing slash)."
 msgstr ""
 
-#: includes/admin/settings.php:390
+#: includes/admin/settings.php:403
 msgid "Babbel API Username"
 msgstr ""
 
-#: includes/admin/settings.php:397
+#: includes/admin/settings.php:410
 msgid "username"
 msgstr ""
 
-#: includes/admin/settings.php:402
+#: includes/admin/settings.php:415
 msgid "Babbel API Password"
 msgstr ""
 
-#: includes/admin/settings.php:420
+#: includes/admin/settings.php:433
 msgid "Enable Debug Mode"
 msgstr ""
 
-#: includes/admin/settings.php:424
+#: includes/admin/settings.php:437
 msgid "Show debug information and status in the sidebar. Only enable for troubleshooting."
 msgstr ""
 
-#: includes/admin/settings.php:450
+#: includes/admin/settings.php:463
 msgid "OpenAI"
 msgstr ""
 
-#: includes/admin/settings.php:454
+#: includes/admin/settings.php:467
 msgid "Configure OpenAI for generating speech text."
 msgstr ""
 
-#: includes/admin/settings.php:459
+#: includes/admin/settings.php:472
 msgid "OpenAI API Key"
 msgstr ""
 
 #. translators: %s: URL to OpenAI API keys page
-#: includes/admin/settings.php:471
+#: includes/admin/settings.php:484
 #, php-format
 msgid "Your OpenAI API key. Available at %s"
 msgstr ""
 
-#: includes/admin/settings.php:481
+#: includes/admin/settings.php:494
 msgid "OpenAI Model"
 msgstr ""
 
-#: includes/admin/settings.php:489
+#: includes/admin/settings.php:502
 msgid "The OpenAI model for text generation (e.g., gpt-4.1-mini, gpt-4o-mini, gpt-4o)."
 msgstr ""
 
-#: includes/admin/settings.php:495
+#: includes/admin/settings.php:508
 msgid "Few-shot Examples"
 msgstr ""
 
-#: includes/admin/settings.php:505
+#: includes/admin/settings.php:518
 msgid "Number of editor-corrected examples to include in the speech prompt (0 to disable, max 20). Synced nightly from Babbel."
 msgstr ""
 
-#: includes/admin/settings.php:529
+#: includes/admin/settings.php:542
 msgid "AI Prompts"
 msgstr ""
 
-#: includes/admin/settings.php:533
+#: includes/admin/settings.php:546
 msgid "Customize the AI prompt for generating speech text."
 msgstr ""
 
-#: includes/admin/settings.php:538
+#: includes/admin/settings.php:551
 msgid "Speech Text Generation Prompt"
 msgstr ""
 
-#: includes/admin/settings.php:546
+#: includes/admin/settings.php:559
 msgid "Prompt for converting to radio-friendly speech text. Leave empty for default prompt."
 msgstr ""
 
-#: includes/admin/settings.php:562
+#: includes/admin/settings.php:575
 msgid "Sun"
 msgstr ""
 
-#: includes/admin/settings.php:563
+#: includes/admin/settings.php:576
 msgid "Mon"
 msgstr ""
 
-#: includes/admin/settings.php:564
+#: includes/admin/settings.php:577
 msgid "Tue"
 msgstr ""
 
-#: includes/admin/settings.php:565
+#: includes/admin/settings.php:578
 msgid "Wed"
 msgstr ""
 
-#: includes/admin/settings.php:566
+#: includes/admin/settings.php:579
 msgid "Thu"
 msgstr ""
 
-#: includes/admin/settings.php:567
+#: includes/admin/settings.php:580
 msgid "Fri"
 msgstr ""
 
-#: includes/admin/settings.php:568
+#: includes/admin/settings.php:581
 msgid "Sat"
 msgstr ""
 
-#: includes/admin/settings.php:575
+#: includes/admin/settings.php:588
 msgid "Story Defaults"
 msgstr ""
 
-#: includes/admin/settings.php:580
+#: includes/admin/settings.php:593
 msgid "Start Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:588
+#: includes/admin/settings.php:601
 msgid "Number of days from publication for start date."
 msgstr ""
 
-#: includes/admin/settings.php:593
+#: includes/admin/settings.php:606
 msgid "End Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:601
+#: includes/admin/settings.php:614
 msgid "Number of days from publication for end date."
 msgstr ""
 
-#: includes/admin/settings.php:615
+#: includes/admin/settings.php:628
 msgid "Active"
 msgstr ""
 
-#: includes/admin/settings.php:620
+#: includes/admin/settings.php:633
 msgid "Days"
 msgstr ""
 
-#: includes/admin/settings.php:638
+#: includes/admin/settings.php:651
 msgid "Which days the story may be broadcast."
 msgstr ""
 
-#: includes/admin/settings.php:752
+#: includes/admin/settings.php:765
 msgid "Knabbel Story Debug Overview"
 msgstr ""
 
-#: includes/admin/settings.php:766
+#: includes/admin/settings.php:779
 msgid "Show"
 msgstr ""
 
-#: includes/admin/settings.php:772
+#: includes/admin/settings.php:785
 msgid "Article"
 msgstr ""
 
-#: includes/admin/settings.php:790
+#: includes/admin/settings.php:803
 msgid "Last status change"
 msgstr ""
 
-#: includes/admin/settings.php:797
-#: includes/admin/settings.php:812
+#: includes/admin/settings.php:810
+#: includes/admin/settings.php:825
 msgid "Babbel ID"
 msgstr ""
 
-#: includes/admin/settings.php:808
+#: includes/admin/settings.php:821
 #: zw-knabbel-wp.php:632
 msgid "Story is being processed..."
 msgstr ""
 
-#: includes/admin/settings.php:825
+#: includes/admin/settings.php:838
 msgid "Retry"
 msgstr ""
 
-#: includes/admin/settings.php:830
+#: includes/admin/settings.php:843
 msgid "Refresh"
 msgstr ""
 


### PR DESCRIPTION
## Summary

- add a Recent Errors card to the plugin settings page for administrators
- render only timestamp, component, and message; nested context is deliberately not exposed
- show newest errors first and escape every stored value at output
- add a `manage_options` and nonce-protected action to clear the rolling list
- show a success notice after clearing
- update the plugin POT catalog for the new admin strings

Closes #21

## Dependency

#27 addresses #20 and makes the store reliable outside `WP_DEBUG_LOG`, bounds/allowlists stored data, and marks the option non-autoloaded. This PR is independently safe on `main` because it never renders context, while merging #27 completes the production-storage side of the feature.

## Security

- settings page and clear handler both require `manage_options`
- clear action uses `check_admin_referer()`
- all rendered values use `esc_html()`
- nested context, complete responses, and response bodies are never rendered

## Testing

- `php -l includes/admin/settings.php`
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `npm run lint`
- `git diff --check`
- `wp i18n make-pot . languages/zw-knabbel-wp.pot --slug=zw-knabbel-wp --domain=zw-knabbel-wp`

## WordPress Playground smoke test

Tested with PHP 8.3 and latest WordPress in an ephemeral Playground instance:

- plugin activated without a fatal error
- settings page rendered the Recent Errors card with two seeded entries
- deliberately seeded nested HTML/script context did not appear in the page HTML
- browser rendering showed the timestamp, component, and message columns correctly
- the nonce-protected Clear Errors action removed the option and displayed the success notice

A local browser screenshot was captured at 1238x229 and visually inspected; the card renders cleanly with the two error rows and Clear Errors button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Recent Errors” section to the admin settings page with a sanitized, timestamped table of recent entries.
  * Added a nonce-protected “Clear Errors” action that removes stored entries and shows a confirmation notice.
* **Bug Fixes**
  * Refreshed and expanded translated admin/workflow/status and Babbel API error messages for clearer UI feedback.
* **Documentation**
  * Updated the translation template metadata and regenerated related settings/workflow string references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->