### PR TITLE
fix: expose Babbel sync failures

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -72,6 +72,19 @@
     margin: 4px 0 0;
 }
 
+.knabbel-sync-warning {
+    margin-top: 8px;
+    padding: 8px 10px;
+    border-left: 4px solid #dba617;
+    background: #fcf9e8;
+    color: #1d2327;
+}
+
+.knabbel-sync-warning strong {
+    display: block;
+    margin-bottom: 3px;
+}
+
 /* ==========================================================================
    Toggle Switch - settings page
    ========================================================================== */

--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -116,7 +116,7 @@ function metabox_render( \WP_Post $post ): void {
 		echo '</label>';
 		echo '</p>';
 
-	if ( $sync_error && ! empty( $sync_error['message'] ) ) {
+	if ( is_story_sync_error_renderable( $sync_error ) && null !== $sync_error ) {
 		echo '<div class="knabbel-sync-warning" role="alert">';
 		echo '<strong>' . esc_html__( 'Babbel sync warning', 'zw-knabbel-wp' ) . '</strong>';
 		echo '<div>' . esc_html( $sync_error['message'] ) . '</div>';
@@ -181,7 +181,7 @@ function metabox_render_status( \WP_Post $post ): void {
 				?>
 			</li>
 			<?php endif; ?>
-			<?php if ( $sync_error && ! empty( $sync_error['message'] ) ) : ?>
+			<?php if ( is_story_sync_error_renderable( $sync_error ) && null !== $sync_error ) : ?>
 			<li>
 				<strong><?php esc_html_e( 'Last sync error', 'zw-knabbel-wp' ); ?>:</strong>
 				<div class="knabbel-sync-warning">
@@ -205,7 +205,7 @@ function metabox_render_status( \WP_Post $post ): void {
 				</div>
 			</li>
 			<?php endif; ?>
-			<?php if ( ! empty( $message ) && ! $sync_error ) : ?>
+			<?php if ( ! empty( $message ) && ! is_story_sync_error_renderable( $sync_error ) ) : ?>
 			<li>
 				<strong><?php esc_html_e( 'Message', 'zw-knabbel-wp' ); ?>:</strong>
 				<div class="knabbel-pre"><?php echo esc_html( $message ); ?></div>

--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -106,6 +106,8 @@ function metabox_render( \WP_Post $post ): void {
 		wp_nonce_field( 'knabbel_metabox_nonce', 'knabbel_nonce' );
 
 		$send_to_babbel = get_post_meta( $post->ID, '_zw_knabbel_send_to_babbel', true );
+		$state          = get_story_state( $post->ID );
+		$sync_error     = get_story_sync_error( $state );
 
 		echo '<p>';
 		echo '<label for="knabbel_send_to_babbel">';
@@ -113,6 +115,13 @@ function metabox_render( \WP_Post $post ): void {
 		echo ' ' . esc_html__( 'Radio News', 'zw-knabbel-wp' );
 		echo '</label>';
 		echo '</p>';
+
+	if ( $sync_error && ! empty( $sync_error['message'] ) ) {
+		echo '<div class="knabbel-sync-warning" role="alert">';
+		echo '<strong>' . esc_html__( 'Babbel sync warning', 'zw-knabbel-wp' ) . '</strong>';
+		echo '<div>' . esc_html( $sync_error['message'] ) . '</div>';
+		echo '</div>';
+	}
 }
 
 /**
@@ -123,12 +132,13 @@ function metabox_render( \WP_Post $post ): void {
  * @param \WP_Post $post The current post object.
  */
 function metabox_render_status( \WP_Post $post ): void {
-		$state     = get_post_meta( $post->ID, '_zw_knabbel_story_state', true );
-		$status    = is_array( $state ) && ! empty( $state['status'] ) ? $state['status'] : '';
-		$story_id  = is_array( $state ) && ! empty( $state['story_id'] ) ? $state['story_id'] : '';
-		$updated   = is_array( $state ) && ! empty( $state['status_changed_at'] ) ? $state['status_changed_at'] : '';
-		$message   = is_array( $state ) && ! empty( $state['message'] ) ? $state['message'] : '';
-		$scheduled = \as_next_scheduled_action( 'knabbel_process_story', array( 'post_id' => $post->ID ), 'zw-knabbel-wp' );
+		$state      = get_post_meta( $post->ID, '_zw_knabbel_story_state', true );
+		$status     = is_array( $state ) && ! empty( $state['status'] ) ? $state['status'] : '';
+		$story_id   = is_array( $state ) && ! empty( $state['story_id'] ) ? $state['story_id'] : '';
+		$updated    = is_array( $state ) && ! empty( $state['status_changed_at'] ) ? $state['status_changed_at'] : '';
+		$message    = is_array( $state ) && ! empty( $state['message'] ) ? $state['message'] : '';
+		$sync_error = is_array( $state ) ? get_story_sync_error( $state ) : null;
+		$scheduled  = \as_next_scheduled_action( 'knabbel_process_story', array( 'post_id' => $post->ID ), 'zw-knabbel-wp' );
 	?>
 		<ul class="knabbel-status-list">
 			<li>
@@ -171,7 +181,31 @@ function metabox_render_status( \WP_Post $post ): void {
 				?>
 			</li>
 			<?php endif; ?>
-			<?php if ( ! empty( $message ) ) : ?>
+			<?php if ( $sync_error && ! empty( $sync_error['message'] ) ) : ?>
+			<li>
+				<strong><?php esc_html_e( 'Last sync error', 'zw-knabbel-wp' ); ?>:</strong>
+				<div class="knabbel-sync-warning">
+					<?php echo esc_html( $sync_error['message'] ); ?>
+					<?php if ( ! empty( $sync_error['operation'] ) || ! empty( $sync_error['occurred_at'] ) ) : ?>
+						<div class="knabbel-status-muted">
+							<?php if ( ! empty( $sync_error['operation'] ) ) : ?>
+								<?php esc_html_e( 'Operation', 'zw-knabbel-wp' ); ?>:
+								<code><?php echo esc_html( $sync_error['operation'] ); ?></code>
+							<?php endif; ?>
+							<?php if ( ! empty( $sync_error['occurred_at'] ) ) : ?>
+								<?php
+								$sync_error_ts = strtotime( $sync_error['occurred_at'] . ' ' . wp_timezone_string() );
+								if ( $sync_error_ts ) {
+									echo ' · ' . esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $sync_error_ts ) );
+								}
+								?>
+							<?php endif; ?>
+						</div>
+					<?php endif; ?>
+				</div>
+			</li>
+			<?php endif; ?>
+			<?php if ( ! empty( $message ) && ! $sync_error ) : ?>
 			<li>
 				<strong><?php esc_html_e( 'Message', 'zw-knabbel-wp' ); ?>:</strong>
 				<div class="knabbel-pre"><?php echo esc_html( $message ); ?></div>

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -734,17 +734,18 @@ function render_articles_overview(): void {
 		return;
 	}
 
-	$status    = $selected_state['status'] ?? '';
-	$label_map = array(
+	$status     = $selected_state['status'] ?? '';
+	$label_map  = array(
 		'scheduled'  => __( 'Scheduled', 'zw-knabbel-wp' ),
 		'processing' => __( 'Processing', 'zw-knabbel-wp' ),
 		'sent'       => __( 'Sent', 'zw-knabbel-wp' ),
 		'error'      => __( 'Error', 'zw-knabbel-wp' ),
 	);
-	$slug      = $status ? sanitize_key( $status ) : 'none';
-	$label     = $status ? ( $label_map[ $status ] ?? $status ) : '—';
-	$is_error  = 'error' === $status;
-	$is_sent   = 'sent' === $status;
+	$slug       = $status ? sanitize_key( $status ) : 'none';
+	$label      = $status ? ( $label_map[ $status ] ?? $status ) : '—';
+	$is_error   = 'error' === $status;
+	$is_sent    = 'sent' === $status;
+	$sync_error = get_story_sync_error( $selected_state );
 
 	// Build select options.
 	$options_html = '';
@@ -810,7 +811,8 @@ function render_articles_overview(): void {
 					<td class="label-cell"><?php esc_html_e( 'Babbel ID', 'zw-knabbel-wp' ); ?></td>
 					<td class="mono"><?php echo esc_html( $selected_state['story_id'] ); ?></td>
 				</tr>
-				<?php elseif ( $is_error && ! empty( $selected_state['message'] ) ) : ?>
+				<?php endif; ?>
+				<?php if ( $is_error && ! empty( $selected_state['message'] ) && ! $sync_error ) : ?>
 				<tr>
 					<td class="label-cell"><?php esc_html_e( 'Message', 'zw-knabbel-wp' ); ?></td>
 					<td class="error-message"><?php echo esc_html( $selected_state['message'] ); ?></td>
@@ -824,6 +826,29 @@ function render_articles_overview(): void {
 				<tr>
 					<td class="label-cell"><?php esc_html_e( 'Babbel ID', 'zw-knabbel-wp' ); ?></td>
 					<td class="muted">—</td>
+				</tr>
+				<?php endif; ?>
+				<?php if ( $sync_error && ! empty( $sync_error['message'] ) ) : ?>
+				<tr>
+					<td class="label-cell"><?php esc_html_e( 'Last sync error', 'zw-knabbel-wp' ); ?></td>
+					<td class="error-message">
+						<?php echo esc_html( $sync_error['message'] ); ?>
+						<?php if ( ! empty( $sync_error['operation'] ) ) : ?>
+							<div class="muted">
+								<?php esc_html_e( 'Operation', 'zw-knabbel-wp' ); ?>:
+								<code><?php echo esc_html( $sync_error['operation'] ); ?></code>
+							</div>
+						<?php endif; ?>
+						<?php
+						$sync_error_ts = strtotime( $sync_error['occurred_at'] . ' ' . wp_timezone_string() );
+						if ( $sync_error_ts ) :
+							?>
+							<div class="muted">
+								<?php esc_html_e( 'Occurred', 'zw-knabbel-wp' ); ?>:
+								<?php echo esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $sync_error_ts ) ); ?>
+							</div>
+						<?php endif; ?>
+					</td>
 				</tr>
 				<?php endif; ?>
 			</table>

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -812,7 +812,7 @@ function render_articles_overview(): void {
 					<td class="mono"><?php echo esc_html( $selected_state['story_id'] ); ?></td>
 				</tr>
 				<?php endif; ?>
-				<?php if ( $is_error && ! empty( $selected_state['message'] ) && ! $sync_error ) : ?>
+				<?php if ( $is_error && ! empty( $selected_state['message'] ) && ! is_story_sync_error_renderable( $sync_error ) ) : ?>
 				<tr>
 					<td class="label-cell"><?php esc_html_e( 'Message', 'zw-knabbel-wp' ); ?></td>
 					<td class="error-message"><?php echo esc_html( $selected_state['message'] ); ?></td>
@@ -828,7 +828,7 @@ function render_articles_overview(): void {
 					<td class="muted">—</td>
 				</tr>
 				<?php endif; ?>
-				<?php if ( $sync_error && ! empty( $sync_error['message'] ) ) : ?>
+				<?php if ( is_story_sync_error_renderable( $sync_error ) && null !== $sync_error ) : ?>
 				<tr>
 					<td class="label-cell"><?php esc_html_e( 'Last sync error', 'zw-knabbel-wp' ); ?></td>
 					<td class="error-message">

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -434,8 +434,9 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
 		update_story_state(
 			$post_id,
 			array(
-				'status'  => StoryStatus::Error->value,
-				'message' => $result['message'],
+				'status'          => StoryStatus::Error->value,
+				'message'         => $result['message'],
+				'last_sync_error' => build_story_sync_error( $result['message'], 'restore' ),
 			)
 		);
 		return $result;
@@ -447,8 +448,9 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
 		update_story_state(
 			$post_id,
 			array(
-				'status'  => StoryStatus::Sent->value,
-				'message' => __( 'Story restored in Babbel', 'zw-knabbel-wp' ),
+				'status'          => StoryStatus::Sent->value,
+				'message'         => __( 'Story restored in Babbel', 'zw-knabbel-wp' ),
+				'last_sync_error' => null,
 			)
 		);
 	} else {
@@ -466,8 +468,9 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
 		update_story_state(
 			$post_id,
 			array(
-				'status'  => StoryStatus::Sent->value,
-				'message' => __( 'Story restored, but title sync failed', 'zw-knabbel-wp' ),
+				'status'          => StoryStatus::Sent->value,
+				'message'         => __( 'Story restored in Babbel', 'zw-knabbel-wp' ),
+				'last_sync_error' => build_story_sync_error( $title_result['message'], 'restore' ),
 			)
 		);
 	}
@@ -498,8 +501,9 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
 		update_story_state(
 			$post_id,
 			array(
-				'status'  => StoryStatus::Sent->value,
-				'message' => $success_message,
+				'status'          => StoryStatus::Sent->value,
+				'message'         => $success_message,
+				'last_sync_error' => null,
 			)
 		);
 	} else {
@@ -513,6 +517,12 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
 				'context'  => $log_context,
 				'fields'   => array_keys( $update_data ),
 				'error'    => $result['message'],
+			)
+		);
+		update_story_state(
+			$post_id,
+			array(
+				'last_sync_error' => build_story_sync_error( $result['message'], 'update' ),
 			)
 		);
 	}
@@ -534,8 +544,9 @@ function push_story_delete( int $post_id, string $story_id, string $success_mess
 		update_story_state(
 			$post_id,
 			array(
-				'status'  => StoryStatus::Deleted->value,
-				'message' => $success_message,
+				'status'          => StoryStatus::Deleted->value,
+				'message'         => $success_message,
+				'last_sync_error' => null,
 			)
 		);
 		return;
@@ -556,8 +567,7 @@ function push_story_delete( int $post_id, string $story_id, string $success_mess
 	update_story_state(
 		$post_id,
 		array(
-			'status'  => StoryStatus::Error->value,
-			'message' => $result['message'],
+			'last_sync_error' => build_story_sync_error( $result['message'], 'delete' ),
 		)
 	);
 }

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -434,8 +434,6 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
 		update_story_state(
 			$post_id,
 			array(
-				'status'          => StoryStatus::Error->value,
-				'message'         => $result['message'],
 				'last_sync_error' => build_story_sync_error( $result['message'], 'restore' ),
 			)
 		);
@@ -481,9 +479,8 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
 /**
  * Pushes a story update to Babbel and handles the result.
  *
- * On failure, logs the error and leaves the story state untouched: the status
- * stays 'sent' since the story still exists in Babbel (unlike delete failures,
- * which set an error state).
+ * On failure, logs the error while preserving the lifecycle state: the story
+ * still exists in Babbel even though this synchronization attempt failed.
  *
  * @since 0.4.0
  *
@@ -501,7 +498,6 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
 		update_story_state(
 			$post_id,
 			array(
-				'status'          => StoryStatus::Sent->value,
 				'message'         => $success_message,
 				'last_sync_error' => null,
 			)

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-19T13:04:56+00:00\n"
+"POT-Creation-Date: 2026-07-19T13:13:26+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zw-knabbel-wp\n"
@@ -42,7 +42,7 @@ msgid "https://www.zuidwesttv.nl"
 msgstr ""
 
 #: includes/admin/metabox.php:70
-#: includes/admin/metabox.php:113
+#: includes/admin/metabox.php:115
 msgid "Radio News"
 msgstr ""
 
@@ -50,56 +50,70 @@ msgstr ""
 msgid "Knabbel Status"
 msgstr ""
 
-#: includes/admin/metabox.php:135
+#: includes/admin/metabox.php:121
+msgid "Babbel sync warning"
+msgstr ""
+
+#: includes/admin/metabox.php:145
 #: includes/admin/settings.php:619
-#: includes/admin/settings.php:794
+#: includes/admin/settings.php:795
 msgid "Status"
 msgstr ""
 
-#: includes/admin/metabox.php:139
+#: includes/admin/metabox.php:149
 #: includes/admin/settings.php:739
 msgid "Scheduled"
 msgstr ""
 
-#: includes/admin/metabox.php:140
+#: includes/admin/metabox.php:150
 #: includes/admin/settings.php:740
 msgid "Processing"
 msgstr ""
 
-#: includes/admin/metabox.php:141
+#: includes/admin/metabox.php:151
 #: includes/admin/settings.php:741
 msgid "Sent"
 msgstr ""
 
-#: includes/admin/metabox.php:142
+#: includes/admin/metabox.php:152
 #: includes/admin/settings.php:742
 msgid "Error"
 msgstr ""
 
-#: includes/admin/metabox.php:143
+#: includes/admin/metabox.php:153
 msgid "Deleted"
 msgstr ""
 
-#: includes/admin/metabox.php:145
+#: includes/admin/metabox.php:155
 msgid "—"
 msgstr ""
 
-#: includes/admin/metabox.php:151
+#: includes/admin/metabox.php:161
 msgid "Last status change:"
 msgstr ""
 
-#: includes/admin/metabox.php:161
+#: includes/admin/metabox.php:171
 msgid "Story ID"
 msgstr ""
 
-#: includes/admin/metabox.php:167
+#: includes/admin/metabox.php:177
 msgid "Scheduled:"
 msgstr ""
 
-#: includes/admin/metabox.php:176
+#: includes/admin/metabox.php:186
+#: includes/admin/settings.php:833
+msgid "Last sync error"
+msgstr ""
+
+#: includes/admin/metabox.php:192
+#: includes/admin/settings.php:838
+msgid "Operation"
+msgstr ""
+
+#: includes/admin/metabox.php:210
 #: includes/admin/settings.php:300
-#: includes/admin/settings.php:815
-#: includes/admin/settings.php:820
+#: includes/admin/settings.php:817
+#: includes/admin/settings.php:822
 msgid "Message"
 msgstr ""
 
@@ -306,37 +320,41 @@ msgstr ""
 msgid "Which days the story may be broadcast."
 msgstr ""
 
-#: includes/admin/settings.php:765
+#: includes/admin/settings.php:766
 msgid "Knabbel Story Debug Overview"
 msgstr ""
 
-#: includes/admin/settings.php:779
+#: includes/admin/settings.php:780
 msgid "Show"
 msgstr ""
 
-#: includes/admin/settings.php:785
+#: includes/admin/settings.php:786
 msgid "Article"
 msgstr ""
 
-#: includes/admin/settings.php:803
+#: includes/admin/settings.php:804
 msgid "Last status change"
 msgstr ""
 
-#: includes/admin/settings.php:810
-#: includes/admin/settings.php:825
+#: includes/admin/settings.php:811
+#: includes/admin/settings.php:827
 msgid "Babbel ID"
 msgstr ""
 
-#: includes/admin/settings.php:821
-#: zw-knabbel-wp.php:632
+#: includes/admin/settings.php:823
+#: zw-knabbel-wp.php:687
 msgid "Story is being processed..."
 msgstr ""
 
-#: includes/admin/settings.php:838
+#: includes/admin/settings.php:847
+msgid "Occurred"
+msgstr ""
+
+#: includes/admin/settings.php:863
 msgid "Retry"
 msgstr ""
 
-#: includes/admin/settings.php:843
+#: includes/admin/settings.php:868
 msgid "Refresh"
 msgstr ""
 
@@ -389,7 +407,7 @@ msgid "No story ID received from API"
 msgstr ""
 
 #: includes/babbel-api.php:316
-#: zw-knabbel-wp.php:687
+#: zw-knabbel-wp.php:742
 msgid "Story created successfully"
 msgstr ""
 
@@ -469,42 +487,39 @@ msgstr ""
 msgid "Story deleted (post trashed)"
 msgstr ""
 
-#: includes/post-hooks.php:451
+#: includes/post-hooks.php:450
+#: includes/post-hooks.php:470
 msgid "Story restored in Babbel"
 msgstr ""
 
-#: includes/post-hooks.php:470
-msgid "Story restored, but title sync failed"
-msgstr ""
-
-#: includes/post-hooks.php:634
+#: includes/post-hooks.php:640
 msgid "Processing already scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:653
+#: includes/post-hooks.php:659
 msgid "Processing scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:661
+#: includes/post-hooks.php:667
 msgid "Could not schedule action"
 msgstr ""
 
-#: zw-knabbel-wp.php:557
+#: zw-knabbel-wp.php:612
 msgid "Insufficient permissions"
 msgstr ""
 
-#: zw-knabbel-wp.php:596
+#: zw-knabbel-wp.php:651
 msgid "Already sent — skipping"
 msgstr ""
 
-#: zw-knabbel-wp.php:608
+#: zw-knabbel-wp.php:663
 msgid "Post not found"
 msgstr ""
 
-#: zw-knabbel-wp.php:621
+#: zw-knabbel-wp.php:676
 msgid "Send to Babbel is disabled for this post"
 msgstr ""
 
-#: zw-knabbel-wp.php:648
+#: zw-knabbel-wp.php:703
 msgid "Could not generate speech text"
 msgstr ""

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,7 +16,9 @@ parameters:
     BabbelApiResponse: 'array{success: bool, message: string, story_id?: string}'
     StoryData: 'array{title: string, text: string, start_date: string, end_date: string, status?: string, weekdays?: int, metadata?: array<string, mixed>}'
     StoryUpdateData: 'array{title?: string, start_date?: string, end_date?: string, weekdays?: int}'
-    StoryState: 'array{status?: string, story_id?: string, status_changed_at?: string, message?: string, generated_speech_text?: string}'
+    LastSyncError: 'array{message: string, occurred_at: string, operation: string}'
+    StoryState: 'array{status?: string, story_id?: string, status_changed_at?: string, message?: string, generated_speech_text?: string, post_id?: int, last_sync_error?: LastSyncError}'
+    StoryStateUpdate: 'array{status?: string, story_id?: string, message?: string, generated_speech_text?: string, last_sync_error?: LastSyncError|null}'
     RecentError: 'array{timestamp: string, component: string, message: string, context: array<string, mixed>}'
     # OpenAI types
     OpenAISettings: 'array{api_key: string|null, model: string, api_base_url: string}'

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -342,26 +342,35 @@ function log( string $level, string $component, string $message, array $context 
  * Triggers WordPress action hook for extensibility.
  *
  * @since 0.1.0
- * @param int                                                         $post_id The post ID.
- * @param array{status?: string, story_id?: string, message?: string} $updates Partial state updates to apply.
+ * @param int                  $post_id The post ID.
+ * @param array<string, mixed> $updates Partial state updates to apply.
  * @return bool True on successful update, false on failure.
  *
- * @phpstan-param StoryState $updates
+ * @phpstan-param StoryStateUpdate $updates
  */
 function update_story_state( int $post_id, array $updates = array() ): bool {
 	// Single read operation.
 	$meta_value    = get_post_meta( $post_id, '_zw_knabbel_story_state', true );
 	$current_state = is_array( $meta_value ) ? $meta_value : array();
 
-	// Merge updates with current state and add timestamp.
+	// Merge updates with current state. A sync-health-only update must not
+	// change the lifecycle status timestamp.
 	$new_state = array_merge(
 		$current_state,
 		$updates,
 		array(
-			'status_changed_at' => current_time( 'mysql' ),
-			'post_id'           => $post_id,
+			'post_id' => $post_id,
 		)
 	);
+
+	if ( array_key_exists( 'status', $updates ) ) {
+		$new_state['status_changed_at'] = current_time( 'mysql' );
+	}
+
+	// Null is an update-only sentinel: remove the error instead of persisting it.
+	if ( array_key_exists( 'last_sync_error', $updates ) && null === $updates['last_sync_error'] ) {
+		unset( $new_state['last_sync_error'] );
+	}
 
 	// Single write operation for all data.
 	$success = update_post_meta( $post_id, '_zw_knabbel_story_state', $new_state );
@@ -389,13 +398,59 @@ function update_story_state( int $post_id, array $updates = array() ): bool {
  * @param int $post_id The post ID.
  *
  * phpcs:ignore Generic.Files.LineLength.TooLong -- Type annotation.
- * @return array{status?: string, story_id?: string, status_changed_at?: string, message?: string, post_id?: int} Story state data or empty array if none exists.
+ * @return array{status?: string, story_id?: string, status_changed_at?: string, message?: string, post_id?: int, last_sync_error?: array{message: string, occurred_at: string, operation: string}} Story state data or empty array if none exists.
  *
  * @phpstan-return StoryState
  */
 function get_story_state( int $post_id ): array {
 	$state = get_post_meta( $post_id, '_zw_knabbel_story_state', true );
 	return is_array( $state ) ? $state : array();
+}
+
+/**
+ * Builds a bounded sync error for persistent story state.
+ *
+ * @since 0.4.0
+ * @param string $message   Error message to show to operators and editors.
+ * @param string $operation Sync operation: create, update, restore, or delete.
+ * @return array{message: string, occurred_at: string, operation: string} Sync error data.
+ *
+ * @phpstan-return LastSyncError
+ */
+function build_story_sync_error( string $message, string $operation ): array {
+	$allowed_operations = array( 'create', 'update', 'restore', 'delete' );
+	$operation          = sanitize_key( $operation );
+
+	return array(
+		'message'     => wp_html_excerpt( sanitize_textarea_field( $message ), 500, '' ),
+		'occurred_at' => current_time( 'mysql' ),
+		'operation'   => in_array( $operation, $allowed_operations, true ) ? $operation : 'update',
+	);
+}
+
+/**
+ * Reads a valid sync error from story state.
+ *
+ * @since 0.4.0
+ * @param array<string, mixed> $state Story state data.
+ * @return array{message: string, occurred_at: string, operation: string}|null Sync error, or null when absent or malformed.
+ *
+ * @phpstan-return LastSyncError|null
+ */
+function get_story_sync_error( array $state ): ?array {
+	$error = $state['last_sync_error'] ?? null;
+	if ( ! is_array( $error ) || ! isset( $error['message'], $error['occurred_at'], $error['operation'] ) ) {
+		return null;
+	}
+	if ( ! is_string( $error['message'] ) || ! is_string( $error['occurred_at'] ) || ! is_string( $error['operation'] ) ) {
+		return null;
+	}
+
+	return array(
+		'message'     => $error['message'],
+		'occurred_at' => $error['occurred_at'],
+		'operation'   => $error['operation'],
+	);
 }
 
 /**
@@ -686,14 +741,16 @@ function process_story_async( int|array $post_id_or_args ): void {
 				'story_id'              => $result['story_id'],
 				'message'               => __( 'Story created successfully', 'zw-knabbel-wp' ),
 				'generated_speech_text' => $speech_text,
+				'last_sync_error'       => null,
 			)
 		);
 	} else {
 		update_story_state(
 			$post_id,
 			array(
-				'status'  => \KnabbelWP\StoryStatus::Error->value,
-				'message' => $result['message'],
+				'status'          => \KnabbelWP\StoryStatus::Error->value,
+				'message'         => $result['message'],
+				'last_sync_error' => build_story_sync_error( $result['message'], 'create' ),
 			)
 		);
 	}

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -454,6 +454,20 @@ function get_story_sync_error( array $state ): ?array {
 }
 
 /**
+ * Determines whether a sync error has a message that can be rendered.
+ *
+ * @since 0.4.0
+ * @param array<string, mixed>|null $sync_error Sync error data.
+ * @return bool Whether the sync error can be rendered.
+ */
+function is_story_sync_error_renderable( ?array $sync_error ): bool {
+	return null !== $sync_error
+		&& isset( $sync_error['message'] )
+		&& is_string( $sync_error['message'] )
+		&& '' !== trim( $sync_error['message'] );
+}
+
+/**
  * Calculate story dates based on a base date and configured offsets.
  *
  * For published posts, base_date should be 'now'.


### PR DESCRIPTION
## Summary

- add a typed `last_sync_error` object with bounded `message`, independent `occurred_at`, and allowlisted `operation`
- keep `status_changed_at` unchanged for sync-health-only updates
- record create, update, restore, and delete failures in story state
- clear stale sync errors after later successful create, update, restore, or delete operations
- show a compact warning in the always-visible Radio News metabox
- show detailed operation/time information in the debug status metabox
- render the sync warning independently in the settings overview so Babbel ID and warning remain visible together
- hide the previous lifecycle message while an active sync error exists
- update PHPStan aliases, PHPDoc shapes, styles, and translations

Closes #22

## State semantics

`last_sync_error` is sync health, not lifecycle status. A failed PUT therefore keeps `status: sent` and leaves `status_changed_at` untouched. The error has its own timestamp. Passing `last_sync_error: null` is an update-only sentinel; it removes the key rather than storing null.

## Security

- persisted error text is sanitized and bounded to 500 characters
- operation is restricted to create/update/restore/delete
- malformed legacy state is ignored by a validating reader
- all admin output is escaped

## Testing

- `php -l` on all changed PHP files
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `npm run lint`
- `git diff --check`
- `wp i18n make-pot . languages/zw-knabbel-wp.pot --slug=zw-knabbel-wp --domain=zw-knabbel-wp`

## WordPress Playground smoke test

Tested with PHP 8.3 and latest WordPress in an ephemeral Playground instance. Executable assertions verified that:

- recording a sync error does not change `status_changed_at`
- persisted markup is stripped
- a later successful sync removes `last_sync_error`
- reseeding an error renders status `sent`, Babbel ID `story-22`, the error message, operation, and independent occurrence time together
- the prior success message is absent while the error is active
- the regular Radio News metabox renders a compact warning for non-debug editors

A 1238x417 browser screenshot of the populated debug overview was captured and visually inspected. The classic metabox HTML was verified directly; Gutenberg keeps that legacy container hidden until its editor UI exposes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clearer “Babbel sync warning” box in the admin metabox and updated the admin/debug UI to show “Last sync error” details (message, optional operation, occurred time).
  * Persist and report structured sync errors for create, update, restore, and delete outcomes.

* **Bug Fixes**
  * Automatically clears prior sync errors after successful restore, update, or delete.
  * Suppresses generic error messaging when a structured sync error is available; normalizes story-state error display.

* **Documentation / Localization**
  * Updated translations for the new warning text and related admin/debug strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->