### PR TITLE
chore: refresh translation source references

### DIFF
--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-19T13:13:26+00:00\n"
+"POT-Creation-Date: 2026-07-19T13:31:41+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zw-knabbel-wp\n"
@@ -342,7 +342,7 @@ msgid "Babbel ID"
 msgstr ""
 
 #: includes/admin/settings.php:823
-#: zw-knabbel-wp.php:687
+#: zw-knabbel-wp.php:701
 msgid "Story is being processed..."
 msgstr ""
 
@@ -407,7 +407,7 @@ msgid "No story ID received from API"
 msgstr ""
 
 #: includes/babbel-api.php:316
-#: zw-knabbel-wp.php:742
+#: zw-knabbel-wp.php:756
 msgid "Story created successfully"
 msgstr ""
 
@@ -504,22 +504,22 @@ msgstr ""
 msgid "Could not schedule action"
 msgstr ""
 
-#: zw-knabbel-wp.php:612
+#: zw-knabbel-wp.php:626
 msgid "Insufficient permissions"
 msgstr ""
 
-#: zw-knabbel-wp.php:651
+#: zw-knabbel-wp.php:665
 msgid "Already sent — skipping"
 msgstr ""
 
-#: zw-knabbel-wp.php:663
+#: zw-knabbel-wp.php:677
 msgid "Post not found"
 msgstr ""
 
-#: zw-knabbel-wp.php:676
+#: zw-knabbel-wp.php:690
 msgid "Send to Babbel is disabled for this post"
 msgstr ""
 
-#: zw-knabbel-wp.php:703
+#: zw-knabbel-wp.php:717
 msgid "Could not generate speech text"
 msgstr ""


### PR DESCRIPTION
## Summary
- regenerate the POT after the sync-error rendering helper shifted source locations
- keep translation references aligned with the merged plugin code

## Testing
- `wp i18n make-pot . languages/zw-knabbel-wp.pot --slug=zw-knabbel-wp --domain=zw-knabbel-wp`
- regenerated-output comparison
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `npm run lint`
- PHP syntax checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed translation catalog metadata and source references.
  * No user-facing translation text was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->