### PR TITLE
test: add WordPress to Babbel end-to-end coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: zw-knabbel-wp
+          persist-credentials: false
 
       - name: Checkout Babbel
         uses: actions/checkout@v7
@@ -46,6 +47,7 @@ jobs:
           repository: oszuidwest/zwfm-babbel
           ref: main
           path: zwfm-babbel
+          persist-credentials: false
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,74 @@
+---
+name: Babbel E2E
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - '**/*.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'tests/e2e/**'
+      - '.github/workflows/e2e.yml'
+  pull_request:
+    paths:
+      - '**/*.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'tests/e2e/**'
+      - '.github/workflows/e2e.yml'
+  schedule:
+    - cron: '30 4 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: WordPress to Babbel
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout plugin
+        uses: actions/checkout@v7
+        with:
+          path: zw-knabbel-wp
+
+      - name: Checkout Babbel
+        uses: actions/checkout@v7
+        with:
+          repository: oszuidwest/zwfm-babbel
+          ref: main
+          path: zwfm-babbel
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install plugin dependencies
+        working-directory: zw-knabbel-wp
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run E2E suite
+        working-directory: zw-knabbel-wp
+        env:
+          BABBEL_PATH: ${{ github.workspace }}/zwfm-babbel
+        run: tests/e2e/run.sh
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: babbel-e2e-logs
+          path: zw-knabbel-wp/tests/e2e/artifacts/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/shell-quality.yml
+++ b/.github/workflows/shell-quality.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/shell-quality.yml
+++ b/.github/workflows/shell-quality.yml
@@ -1,0 +1,35 @@
+---
+name: Shell Quality
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - '**.sh'
+  pull_request:
+    paths:
+      - '**.sh'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          check_together: "yes"
+          severity: warning

--- a/.github/workflows/shell-quality.yml
+++ b/.github/workflows/shell-quality.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.mo
 *.md
 !README.md
+!tests/e2e/README.md
+/tests/e2e/artifacts/

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -752,13 +752,19 @@ function babbel_fetch_recent_stories( int $limit = 20 ): array|\WP_Error {
  * @global wpdb $wpdb WordPress database abstraction object.
  */
 function babbel_cleanup_sessions(): void {
-	// Clean up cached session transients (WordPress native cleanup).
 	global $wpdb;
-		$wpdb->query(
-			$wpdb->prepare(
-				'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s',
-				'_transient_knabbel_session_%',
-				'_transient_timeout_knabbel_session_%'
-			)
-		);
+
+	$option_names = $wpdb->get_col(
+		$wpdb->prepare(
+			'SELECT option_name FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s',
+			$wpdb->esc_like( '_transient_knabbel_session_' ) . '%',
+			$wpdb->esc_like( '_transient_timeout_knabbel_session_' ) . '%'
+		)
+	);
+
+	foreach ( $option_names as $option_name ) {
+		if ( is_string( $option_name ) ) {
+			delete_option( $option_name );
+		}
+	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,7 @@
     <!-- Files to scan -->
     <file>zw-knabbel-wp.php</file>
     <file>includes</file>
+    <file>tests/e2e</file>
     <file>uninstall.php</file>
 
     <!-- Tooling -->
@@ -44,6 +45,16 @@
             <property name="lineLimit" value="160"/>
             <property name="absoluteLineLimit" value="0"/>
         </properties>
+    </rule>
+
+    <!-- The E2E runner is an executable test suite, not a class autoload target. -->
+    <rule ref="WordPress.Files.FileName.InvalidClassFileName">
+        <exclude-pattern>tests/e2e/suite.php</exclude-pattern>
+    </rule>
+
+    <!-- Exception messages are CLI diagnostics and are never rendered as HTML. -->
+    <rule ref="WordPress.Security.EscapeOutput.ExceptionNotEscaped">
+        <exclude-pattern>tests/e2e/suite.php</exclude-pattern>
     </rule>
 
     <exclude-pattern>vendor/*</exclude-pattern>

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,48 @@
+# Babbel end-to-end tests
+
+This suite validates the complete WordPress-to-Babbel synchronization flow in
+isolated Docker containers. It runs WordPress 7.0.1 on PHP 8.3, a real Babbel
+API built from a local checkout, separate MySQL databases, Action Scheduler,
+and a deterministic WordPress HTTP stub for OpenAI.
+
+## Run locally
+
+Prerequisites:
+
+- Docker with Docker Compose
+- Composer dependencies installed in this plugin repository
+- A local `zwfm-babbel` checkout
+
+From the plugin root:
+
+```bash
+composer install
+BABBEL_PATH=../zwfm-babbel tests/e2e/run.sh
+```
+
+`BABBEL_PATH` must contain Babbel's `Dockerfile` and
+`migrations/001_complete_schema.sql`. The runner creates a unique Compose
+project, removes it after the run, and writes combined container logs to
+`tests/e2e/artifacts/docker.log` on failure.
+
+## Covered scenarios
+
+The regression suite checks:
+
+1. Plugin activation, recurring Action Scheduler setup, Babbel login, session
+   caching, and one-time recovery from an invalid session.
+2. Published story creation, payload fidelity, persisted state, and send-once
+   behavior.
+3. Selective title/content synchronization and recovery from invalid Babbel
+   credentials without leaking secrets.
+4. Checkbox-driven soft delete and restore.
+5. Scheduled, rescheduled, and published date calculations.
+6. Cancellation when a scheduled post returns to draft.
+7. Trash and untrash delete/restore behavior.
+8. OpenAI retry exhaustion without a remote side effect.
+9. Babbel create failure diagnostics.
+10. Few-shot synchronization of editor-corrected speech text and disabling the
+    cache.
+11. Deactivation cleanup of sessions, cached examples, and scheduled actions.
+
+The credentials in the Compose file and suite are isolated test fixtures only.

--- a/tests/e2e/compose.yml
+++ b/tests/e2e/compose.yml
@@ -1,0 +1,110 @@
+---
+services:
+  wordpress-db:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: wordpress-root
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      TZ: Europe/Amsterdam
+    tmpfs:
+      - /var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-pwordpress-root"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  wordpress:
+    image: wordpress:7.0.1-php8.3-apache
+    environment:
+      WORDPRESS_DB_HOST: wordpress-db:3306
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DEBUG: "1"
+      WORDPRESS_CONFIG_EXTRA: |
+        define( 'WP_ENVIRONMENT_TYPE', 'local' );
+        define( 'WP_DEBUG_LOG', true );
+        define( 'DISABLE_WP_CRON', true );
+    volumes:
+      - wordpress-data:/var/www/html
+      - ../..:/var/www/html/wp-content/plugins/zw-knabbel-wp:ro
+      - ./mu-plugins:/var/www/html/wp-content/mu-plugins:ro
+    depends_on:
+      wordpress-db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "php -r 'exit(@file_get_contents(\"http://localhost/wp-login.php\") === false ? 1 : 0);'"
+      interval: 2s
+      timeout: 5s
+      retries: 45
+
+  wordpress-cli:
+    image: wordpress:cli-2.12.0-php8.3
+    working_dir: /var/www/html
+    environment:
+      WORDPRESS_DB_HOST: wordpress-db:3306
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+    volumes:
+      - wordpress-data:/var/www/html
+      - ../..:/var/www/html/wp-content/plugins/zw-knabbel-wp:ro
+      - ./mu-plugins:/var/www/html/wp-content/mu-plugins:ro
+    depends_on:
+      wordpress-db:
+        condition: service_healthy
+      wordpress:
+        condition: service_healthy
+
+  babbel-db:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: babbel-root
+      MYSQL_DATABASE: babbel
+      MYSQL_USER: babbel
+      MYSQL_PASSWORD: babbel
+      TZ: Europe/Amsterdam
+    tmpfs:
+      - /var/lib/mysql
+    volumes:
+      - ${BABBEL_PATH:?Set BABBEL_PATH to a zwfm-babbel checkout}/migrations/001_complete_schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "mysql --host=127.0.0.1 --user=babbel --password=babbel --database=babbel --execute='SELECT 1 FROM users LIMIT 1'"
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  babbel:
+    build:
+      context: ${BABBEL_PATH:?Set BABBEL_PATH to a zwfm-babbel checkout}
+    environment:
+      BABBEL_DB_HOST: babbel-db
+      BABBEL_DB_USER: babbel
+      BABBEL_DB_PASSWORD: babbel
+      BABBEL_DB_NAME: babbel
+      BABBEL_SERVER_ADDRESS: :8080
+      BABBEL_AUTH_METHOD: local
+      BABBEL_SESSION_SECRET: e2e-only-session-secret-at-least-32-characters
+      BABBEL_ENV: development
+      BABBEL_FFMPEG_PATH: ffmpeg
+      BABBEL_FFPROBE_PATH: ffprobe
+      TZ: Europe/Amsterdam
+    depends_on:
+      babbel-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      interval: 2s
+      timeout: 5s
+      retries: 45
+      start_period: 5s
+
+volumes:
+  wordpress-data:

--- a/tests/e2e/mu-plugins/knabbel-openai-stub.php
+++ b/tests/e2e/mu-plugins/knabbel-openai-stub.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Plugin Name: Knabbel E2E OpenAI Stub
+ * Description: Deterministic OpenAI transport for the isolated E2E environment.
+ *
+ * @package KnabbelWP
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_filter(
+	'pre_http_request',
+	static function ( false|array|WP_Error $preempt, array $parsed_args, string $url ): false|array|WP_Error {
+		unset( $parsed_args );
+
+		if ( 'https://api.openai.com/v1/chat/completions' !== $url ) {
+			return $preempt;
+		}
+
+		$call_count = (int) get_option( 'knabbel_e2e_openai_call_count', 0 );
+		update_option( 'knabbel_e2e_openai_call_count', $call_count + 1, false );
+
+		if ( 'error' === get_option( 'knabbel_e2e_openai_mode', 'success' ) ) {
+			return new WP_Error( 'knabbel_e2e_openai_error', 'Deterministic OpenAI failure' );
+		}
+
+		return array(
+			'headers'  => array( 'content-type' => 'application/json' ),
+			'body'     => wp_json_encode(
+				array(
+					'choices' => array(
+						array(
+							'message' => array(
+								'content' => 'Deterministische E2E-radiospreektekst.',
+							),
+						),
+					),
+				)
+			),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	},
+	10,
+	3
+);

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../.." && pwd)
+babbel_path=${BABBEL_PATH:-}
+
+if [[ -z "$babbel_path" ]]; then
+	echo "BABBEL_PATH must point to a zwfm-babbel checkout." >&2
+	exit 2
+fi
+
+babbel_path=$(cd "$babbel_path" && pwd)
+if [[ ! -f "$babbel_path/Dockerfile" || ! -f "$babbel_path/migrations/001_complete_schema.sql" ]]; then
+	echo "BABBEL_PATH is not a usable zwfm-babbel checkout: $babbel_path" >&2
+	exit 2
+fi
+
+if [[ ! -f "$repo_root/vendor/autoload.php" ]]; then
+	echo "Composer dependencies are missing. Run composer install first." >&2
+	exit 2
+fi
+
+command -v docker >/dev/null 2>&1 || {
+	echo "Docker is required for the E2E suite." >&2
+	exit 2
+}
+
+project_name=${COMPOSE_PROJECT_NAME:-zw-knabbel-e2e-$$}
+artifact_dir="$script_dir/artifacts"
+export BABBEL_PATH="$babbel_path"
+
+compose=(docker compose --project-name "$project_name" --file "$script_dir/compose.yml")
+
+cleanup() {
+	status=$?
+	trap - EXIT
+
+	if ((status != 0)); then
+		mkdir -p "$artifact_dir"
+		"${compose[@]}" ps --all || true
+		"${compose[@]}" logs --no-color >"$artifact_dir/docker.log" 2>&1 || true
+		tail -n 300 "$artifact_dir/docker.log" || true
+	fi
+
+	"${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
+	exit "$status"
+}
+trap cleanup EXIT
+
+wait_for_service() {
+	local service=$1
+	local container_id
+	local status
+
+	container_id=$("${compose[@]}" ps --quiet "$service")
+	if [[ -z "$container_id" ]]; then
+		echo "Service did not start: $service" >&2
+		return 1
+	fi
+
+	for _ in {1..90}; do
+		status=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id")
+		if [[ "$status" == "healthy" ]]; then
+			return 0
+		fi
+		if [[ "$status" == "unhealthy" || "$status" == "exited" || "$status" == "dead" ]]; then
+			echo "Service $service entered state $status." >&2
+			return 1
+		fi
+		sleep 2
+	done
+
+	echo "Timed out waiting for service $service." >&2
+	return 1
+}
+
+wp() {
+	"${compose[@]}" run --rm --no-deps wordpress-cli wp "$@"
+}
+
+rm -rf "$artifact_dir"
+
+echo "Starting isolated WordPress and Babbel services..."
+"${compose[@]}" up --detach --build wordpress-db babbel-db babbel wordpress
+wait_for_service wordpress-db
+wait_for_service babbel-db
+wait_for_service babbel
+wait_for_service wordpress
+
+echo "Installing WordPress..."
+wp core install \
+	--url=http://wordpress \
+	--title='Knabbel E2E' \
+	--admin_user=admin \
+	--admin_password=e2e-admin-password \
+	--admin_email=e2e@example.test \
+	--skip-email
+wp option update timezone_string Europe/Amsterdam
+wp plugin activate zw-knabbel-wp
+
+echo "Running E2E regression suite..."
+wp eval 'require "/var/www/html/wp-content/plugins/zw-knabbel-wp/tests/e2e/suite.php";'

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 
 use KnabbelWP\StoryStatus;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	throw new RuntimeException( 'Run this suite through WP-CLI.' );
 }

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -178,7 +178,7 @@ final class Knabbel_E2E_Suite {
 		update_post_meta( $post_id, '_zw_knabbel_send_to_babbel', 1 );
 		$this->assert_same( 0, $this->story_action_count( $post_id ), 'Enabling a draft must not schedule processing.' );
 
-		$expected_dates = KnabbelWP\calculate_story_dates( 'now' );
+		$dates_before = KnabbelWP\calculate_story_dates( 'now' );
 		$this->update_post( $post_id, array( 'post_status' => 'publish' ) );
 		$this->assert_same(
 			StoryStatus::Scheduled->value,
@@ -191,7 +191,8 @@ final class Knabbel_E2E_Suite {
 		$this->assert_same( 1, $this->story_action_count( $post_id ), 'Repeated saves must not duplicate the pending action.' );
 
 		$this->run_action_scheduler( self::STORY_HOOK );
-		$state = KnabbelWP\get_story_state( $post_id );
+		$dates_after = KnabbelWP\calculate_story_dates( 'now' );
+		$state       = KnabbelWP\get_story_state( $post_id );
 		$this->assert_same( StoryStatus::Sent->value, $state['status'] ?? null, 'The worker must mark a created story sent.' );
 		$this->assert_not_empty( $state['story_id'] ?? '', 'The worker must persist the Babbel story ID.' );
 		$this->assert_same( self::GENERATED_TEXT, $state['generated_speech_text'] ?? null, 'The generated speech text must be persisted.' );
@@ -199,8 +200,18 @@ final class Knabbel_E2E_Suite {
 		$story = $this->get_babbel_story( (string) $state['story_id'] );
 		$this->assert_same( $title, $story['title'] ?? null, 'Babbel must receive the raw WordPress title.' );
 		$this->assert_same( self::GENERATED_TEXT, $story['text'] ?? null, 'Babbel must receive the generated speech text.' );
-		$this->assert_same( $expected_dates['start_date'], $this->date_only( $story['start_date'] ?? '' ), 'Published story start date must be based on now.' );
-		$this->assert_same( $expected_dates['end_date'], $this->date_only( $story['end_date'] ?? '' ), 'Published story end date must be based on now.' );
+		$this->assert_date_within_window(
+			$this->date_only( $story['start_date'] ?? '' ),
+			$dates_before['start_date'],
+			$dates_after['start_date'],
+			'Published story start date must be based on the processing date.'
+		);
+		$this->assert_date_within_window(
+			$this->date_only( $story['end_date'] ?? '' ),
+			$dates_before['end_date'],
+			$dates_after['end_date'],
+			'Published story end date must be based on the processing date.'
+		);
 		$this->assert_same( 127, $story['weekdays'] ?? null, 'All configured weekdays must produce bitmask 127.' );
 		$this->assert_same( 'draft', $story['status'] ?? null, 'Babbel must receive the configured default status.' );
 		$this->assert_same( $post_id, (int) ( $story['metadata']['wordpress_id'] ?? 0 ), 'Babbel metadata must link to the WordPress post.' );
@@ -222,10 +233,21 @@ final class Knabbel_E2E_Suite {
 	 */
 	private function test_update_and_error_recovery(): void {
 		$original_story = $this->get_babbel_story( $this->published_story_id );
-		$new_content    = 'De inhoud verandert, maar bestaand Babbel-speechmateriaal blijft bewust en aantoonbaar ongewijzigd.';
+		$edited_text    = 'Dit is de door de redactie aangepaste Babbel-speechtekst die behouden moet blijven.';
+		$response       = $this->babbel_request(
+			'PUT',
+			'/stories/' . $this->published_story_id,
+			array(
+				'text'   => $edited_text,
+				'status' => $original_story['status'] ?? 'draft',
+			)
+		);
+		$this->assert_same( 200, wp_remote_retrieve_response_code( $response ), 'The fixture speech text must be editable in Babbel.' );
+
+		$new_content = 'De inhoud verandert, maar bestaand Babbel-speechmateriaal blijft bewust en aantoonbaar ongewijzigd.';
 		$this->update_post( $this->published_post_id, array( 'post_content' => $new_content ) );
 		$story = $this->get_babbel_story( $this->published_story_id );
-		$this->assert_same( $original_story['text'] ?? null, $story['text'] ?? null, 'Content-only edits must not overwrite edited Babbel speech text.' );
+		$this->assert_same( $edited_text, $story['text'] ?? null, 'Content-only edits must not overwrite edited Babbel speech text.' );
 
 		$this->update_post( $this->published_post_id, array( 'post_title' => 'E2E titel gesynchroniseerd' ) );
 		$story = $this->get_babbel_story( $this->published_story_id );
@@ -317,7 +339,7 @@ final class Knabbel_E2E_Suite {
 		$this->assert_same( 'E2E opnieuw gepland', $story['title'] ?? null, 'Rescheduling must synchronize the title.' );
 		$this->assert_same( $dates['start_date'], $this->date_only( $story['start_date'] ?? '' ), 'Rescheduling must recalculate story dates.' );
 
-		$published_dates = KnabbelWP\calculate_story_dates( 'now' );
+		$dates_before = KnabbelWP\calculate_story_dates( 'now' );
 		$this->update_post(
 			$post_id,
 			array(
@@ -326,16 +348,19 @@ final class Knabbel_E2E_Suite {
 				'post_date_gmt' => current_time( 'mysql', true ),
 			)
 		);
-		$story = $this->get_babbel_story( $story_id );
-		$this->assert_same(
-			$published_dates['start_date'],
+		$story       = $this->get_babbel_story( $story_id );
+		$dates_after = KnabbelWP\calculate_story_dates( 'now' );
+		$this->assert_date_within_window(
 			$this->date_only( $story['start_date'] ?? '' ),
-			'Publishing a scheduled post must recalculate from now.'
+			$dates_before['start_date'],
+			$dates_after['start_date'],
+			'Publishing a scheduled post must recalculate from the processing date.'
 		);
-		$this->assert_same(
-			$published_dates['end_date'],
+		$this->assert_date_within_window(
 			$this->date_only( $story['end_date'] ?? '' ),
-			'Published scheduled story end date must recalculate from now.'
+			$dates_before['end_date'],
+			$dates_after['end_date'],
+			'Published scheduled story end date must recalculate from the processing date.'
 		);
 	}
 
@@ -777,6 +802,18 @@ final class Knabbel_E2E_Suite {
 	 */
 	private function date_only( mixed $value ): string {
 		return is_string( $value ) ? substr( $value, 0, 10 ) : '';
+	}
+
+	/**
+	 * Assert a date was calculated within a captured processing window.
+	 *
+	 * @param string $actual   Actual API date.
+	 * @param string $earliest Expected date before processing.
+	 * @param string $latest   Expected date after processing.
+	 * @param string $message  Failure message.
+	 */
+	private function assert_date_within_window( string $actual, string $earliest, string $latest, string $message ): void {
+		$this->assert_true( in_array( $actual, array( $earliest, $latest ), true ), $message );
 	}
 
 	/**

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -1,0 +1,869 @@
+<?php
+/**
+ * End-to-end regression suite for the WordPress to Babbel synchronization flow.
+ *
+ * @package KnabbelWP
+ */
+
+declare(strict_types=1);
+
+use KnabbelWP\StoryStatus;
+
+if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+	throw new RuntimeException( 'Run this suite through WP-CLI.' );
+}
+
+/**
+ * Runs stateful integration scenarios against isolated WordPress and Babbel databases.
+ */
+final class Knabbel_E2E_Suite {
+	private const BABBEL_BASE_URL = 'http://babbel:8080/api/v1';
+	private const STORY_HOOK      = 'knabbel_process_story';
+	private const FEW_SHOT_HOOK   = 'knabbel_sync_few_shot_examples';
+	private const ACTION_GROUP    = 'zw-knabbel-wp';
+	private const GENERATED_TEXT  = 'Deterministische E2E-radiospreektekst.';
+
+	/**
+	 * Cookies for the independent Babbel verification client.
+	 *
+	 * @var array<int, WP_Http_Cookie>
+	 */
+	private array $babbel_cookies = array();
+
+	/**
+	 * Number of assertions completed by the suite.
+	 *
+	 * @var int
+	 */
+	private int $assertion_count = 0;
+
+	/**
+	 * WordPress ID of the shared published fixture.
+	 *
+	 * @var int
+	 */
+	private int $published_post_id = 0;
+
+	/**
+	 * Babbel ID of the shared published fixture.
+	 *
+	 * @var string
+	 */
+	private string $published_story_id = '';
+
+	/**
+	 * Execute all scenarios in dependency order.
+	 */
+	public function run(): void {
+		$this->run_case( 'E2E-001', 'plugin activation, recurring queue and Babbel authentication', fn() => $this->test_bootstrap_and_authentication() );
+		$this->run_case( 'E2E-002', 'published post creates exactly one complete Babbel story', fn() => $this->test_published_story_creation() );
+		$this->run_case( 'E2E-003', 'edits synchronize and recover from an authentication failure', fn() => $this->test_update_and_error_recovery() );
+		$this->run_case( 'E2E-004', 'checkbox disable soft-deletes and re-enable restores', fn() => $this->test_checkbox_delete_and_restore() );
+		$this->run_case( 'E2E-005', 'scheduled post dates update when scheduled and published', fn() => $this->test_scheduled_story_lifecycle() );
+		$this->run_case( 'E2E-006', 'unscheduling cancels pending processing without creating a story', fn() => $this->test_pending_schedule_cancellation() );
+		$this->run_case( 'E2E-007', 'trash and untrash delete and restore the same story', fn() => $this->test_trash_and_restore() );
+		$this->run_case( 'E2E-008', 'OpenAI failure retries without creating a Babbel story', fn() => $this->test_openai_failure() );
+		$this->run_case( 'E2E-009', 'Babbel create failure is visible and preserves diagnostics safely', fn() => $this->test_babbel_create_failure() );
+		$this->run_case( 'E2E-010', 'few-shot queue learns editor changes and honors disable', fn() => $this->test_few_shot_sync() );
+		$this->run_case( 'E2E-011', 'deactivation clears sessions, caches and scheduled actions', fn() => $this->test_deactivation_cleanup() );
+
+		WP_CLI::success( sprintf( '11 E2E scenarios passed with %d assertions.', $this->assertion_count ) );
+	}
+
+	/**
+	 * Run one named case with useful failure context.
+	 *
+	 * @param string   $id       Stable scenario ID.
+	 * @param string   $title    Scenario title.
+	 * @param callable $callback Scenario callback.
+	 */
+	private function run_case( string $id, string $title, callable $callback ): void {
+		WP_CLI::log( sprintf( '[%s] %s', $id, $title ) );
+
+		try {
+			$callback();
+			WP_CLI::log( sprintf( '[%s] PASS', $id ) );
+		} catch ( Throwable $throwable ) {
+			WP_CLI::error( sprintf( '[%s] FAIL: %s', $id, $throwable->getMessage() ) );
+		}
+	}
+
+	/**
+	 * Configure deterministic credentials and story defaults.
+	 *
+	 * @param string $password Babbel password.
+	 */
+	private function configure_plugin( string $password = 'admin' ): void {
+		$settings = get_option( 'knabbel_settings', array() );
+		$this->assert_true( is_array( $settings ), 'Plugin settings must be an array.' );
+
+		$settings = array_merge(
+			$settings,
+			array(
+				'api_base_url'      => self::BABBEL_BASE_URL,
+				'api_username'      => 'admin',
+				'api_password'      => $password,
+				'openai_api_key'    => 'e2e-openai-key',
+				'openai_model'      => 'e2e-model',
+				'start_days_offset' => 1,
+				'end_days_offset'   => 2,
+				'default_status'    => 'draft',
+				'few_shot_count'    => 1,
+				'weekday_sunday'    => 1,
+				'weekday_monday'    => 1,
+				'weekday_tuesday'   => 1,
+				'weekday_wednesday' => 1,
+				'weekday_thursday'  => 1,
+				'weekday_friday'    => 1,
+				'weekday_saturday'  => 1,
+			)
+		);
+
+		update_option( 'knabbel_settings', $settings );
+		KnabbelWP\babbel_clear_session_cache();
+	}
+
+	/**
+	 * Verify activation defaults, a single recurring action, login and 401 retry.
+	 */
+	private function test_bootstrap_and_authentication(): void {
+		$this->assert_true( defined( 'KNABBEL_VERSION' ), 'The plugin bootstrap must be loaded.' );
+
+		$settings = get_option( 'knabbel_settings', array() );
+		$this->assert_same( 1, $settings['start_days_offset'] ?? null, 'Activation must set the default start offset.' );
+		$this->assert_same( 'draft', $settings['default_status'] ?? null, 'Activation must set the default story status.' );
+
+		KnabbelWP\few_shot_schedule_sync();
+		$this->assert_same(
+			1,
+			$this->action_count( self::FEW_SHOT_HOOK, ActionScheduler_Store::STATUS_PENDING ),
+			'The recurring few-shot action must be unique.'
+		);
+
+		$this->configure_plugin();
+		$result = KnabbelWP\babbel_test_connection();
+		$this->assert_true( $result['success'], 'Valid Babbel credentials must connect.' );
+		$this->assert_string_contains( 'admin', $result['message'], 'Connection result must identify the authenticated user.' );
+
+		$cache_key = $this->plugin_session_cache_key();
+		$this->assert_not_empty( get_transient( $cache_key ), 'Successful login must cache session cookies.' );
+
+		$invalid_cookie = new WP_Http_Cookie(
+			array(
+				'name'   => 'babbel_session',
+				'value'  => 'invalid-e2e-session',
+				'path'   => '/',
+				'domain' => 'babbel',
+			)
+		);
+		set_transient( $cache_key, array( $invalid_cookie ), MINUTE_IN_SECONDS );
+
+		$result = KnabbelWP\babbel_test_connection();
+		$this->assert_true( $result['success'], 'A 401 response must clear the cache, authenticate again and retry once.' );
+		$this->assert_not_same( 'invalid-e2e-session', get_transient( $cache_key )[0]->value ?? null, 'The invalid session cookie must be replaced.' );
+	}
+
+	/**
+	 * Verify publish scheduling, queue execution, payload fidelity and send-once safety.
+	 */
+	private function test_published_story_creation(): void {
+		$title   = 'E2E gepubliceerd – één';
+		$content = 'Dit artikel bevat voldoende woorden om de volledige publicatieketen betrouwbaar te testen.';
+
+		$post_id = $this->create_draft( $title, $content );
+		update_post_meta( $post_id, '_zw_knabbel_send_to_babbel', 1 );
+		$this->assert_same( 0, $this->story_action_count( $post_id ), 'Enabling a draft must not schedule processing.' );
+
+		$expected_dates = KnabbelWP\calculate_story_dates( 'now' );
+		$this->update_post( $post_id, array( 'post_status' => 'publish' ) );
+		$this->assert_same(
+			StoryStatus::Scheduled->value,
+			KnabbelWP\get_story_state( $post_id )['status'] ?? null,
+			'Publishing must mark the story scheduled.'
+		);
+		$this->assert_same( 1, $this->story_action_count( $post_id ), 'Publishing must enqueue one action.' );
+
+		$this->update_post( $post_id, array( 'post_title' => $title ) );
+		$this->assert_same( 1, $this->story_action_count( $post_id ), 'Repeated saves must not duplicate the pending action.' );
+
+		$this->run_action_scheduler( self::STORY_HOOK );
+		$state = KnabbelWP\get_story_state( $post_id );
+		$this->assert_same( StoryStatus::Sent->value, $state['status'] ?? null, 'The worker must mark a created story sent.' );
+		$this->assert_not_empty( $state['story_id'] ?? '', 'The worker must persist the Babbel story ID.' );
+		$this->assert_same( self::GENERATED_TEXT, $state['generated_speech_text'] ?? null, 'The generated speech text must be persisted.' );
+
+		$story = $this->get_babbel_story( (string) $state['story_id'] );
+		$this->assert_same( $title, $story['title'] ?? null, 'Babbel must receive the raw WordPress title.' );
+		$this->assert_same( self::GENERATED_TEXT, $story['text'] ?? null, 'Babbel must receive the generated speech text.' );
+		$this->assert_same( $expected_dates['start_date'], $this->date_only( $story['start_date'] ?? '' ), 'Published story start date must be based on now.' );
+		$this->assert_same( $expected_dates['end_date'], $this->date_only( $story['end_date'] ?? '' ), 'Published story end date must be based on now.' );
+		$this->assert_same( 127, $story['weekdays'] ?? null, 'All configured weekdays must produce bitmask 127.' );
+		$this->assert_same( 'draft', $story['status'] ?? null, 'Babbel must receive the configured default status.' );
+		$this->assert_same( $post_id, (int) ( $story['metadata']['wordpress_id'] ?? 0 ), 'Babbel metadata must link to the WordPress post.' );
+		$this->assert_same(
+			self::GENERATED_TEXT,
+			$story['metadata']['original_speech_text'] ?? null,
+			'Babbel metadata must retain the original generated text.'
+		);
+
+		KnabbelWP\process_story_async( $post_id );
+		$this->assert_same( 1, $this->count_babbel_stories_by_title( $title ), 'Re-running the worker must not create a duplicate story.' );
+
+		$this->published_post_id  = $post_id;
+		$this->published_story_id = (string) $state['story_id'];
+	}
+
+	/**
+	 * Verify selective updates and recovery from a real Babbel authentication failure.
+	 */
+	private function test_update_and_error_recovery(): void {
+		$original_story = $this->get_babbel_story( $this->published_story_id );
+		$new_content    = 'De inhoud verandert, maar bestaand Babbel-speechmateriaal blijft bewust en aantoonbaar ongewijzigd.';
+		$this->update_post( $this->published_post_id, array( 'post_content' => $new_content ) );
+		$story = $this->get_babbel_story( $this->published_story_id );
+		$this->assert_same( $original_story['text'] ?? null, $story['text'] ?? null, 'Content-only edits must not overwrite edited Babbel speech text.' );
+
+		$this->update_post( $this->published_post_id, array( 'post_title' => 'E2E titel gesynchroniseerd' ) );
+		$story = $this->get_babbel_story( $this->published_story_id );
+		$this->assert_same( 'E2E titel gesynchroniseerd', $story['title'] ?? null, 'Title edits must synchronize immediately.' );
+
+		$this->configure_plugin( 'definitely-wrong-password' );
+		$this->update_post( $this->published_post_id, array( 'post_title' => 'E2E titel tijdens fout' ) );
+		$state = KnabbelWP\get_story_state( $this->published_post_id );
+		$this->assert_same( StoryStatus::Sent->value, $state['status'] ?? null, 'Update failure must preserve sent lifecycle state.' );
+		$this->assert_same( $this->published_story_id, (string) ( $state['story_id'] ?? '' ), 'Update failure must preserve the story ID.' );
+		$this->assert_same( 'update', $state['last_sync_error']['operation'] ?? null, 'Update failure must persist its operation.' );
+		$story = $this->get_babbel_story( $this->published_story_id );
+		$this->assert_same( 'E2E titel gesynchroniseerd', $story['title'] ?? null, 'Failed update must leave remote data unchanged.' );
+
+		$recent_errors = get_option( 'knabbel_recent_errors', array() );
+		$this->assert_not_empty( $recent_errors, 'A synchronization failure must be visible in recent errors.' );
+		$error_json = wp_json_encode( $recent_errors );
+		$this->assert_false(
+			is_string( $error_json ) && str_contains( $error_json, 'definitely-wrong-password' ),
+			'Persistent diagnostics must never contain the Babbel password.'
+		);
+
+		$this->configure_plugin();
+		$this->update_post( $this->published_post_id, array( 'post_title' => 'E2E titel hersteld' ) );
+		$state = KnabbelWP\get_story_state( $this->published_post_id );
+		$this->assert_false( isset( $state['last_sync_error'] ), 'A successful retry must clear the previous sync error.' );
+		$story = $this->get_babbel_story( $this->published_story_id );
+		$this->assert_same( 'E2E titel hersteld', $story['title'] ?? null, 'Remote title must synchronize after credential recovery.' );
+	}
+
+	/**
+	 * Verify checkbox-driven delete and restore against the real API.
+	 */
+	private function test_checkbox_delete_and_restore(): void {
+		update_post_meta( $this->published_post_id, '_zw_knabbel_send_to_babbel', 0 );
+		$state = KnabbelWP\get_story_state( $this->published_post_id );
+		$this->assert_same( StoryStatus::Deleted->value, $state['status'] ?? null, 'Disabling the checkbox must mark the story deleted.' );
+		$this->assert_babbel_response_code( 404, 'GET', '/stories/' . $this->published_story_id );
+
+		$this->update_post( $this->published_post_id, array( 'post_title' => 'E2E titel na verwijderen' ) );
+		update_post_meta( $this->published_post_id, '_zw_knabbel_send_to_babbel', 1 );
+		$state = KnabbelWP\get_story_state( $this->published_post_id );
+		$this->assert_same( StoryStatus::Sent->value, $state['status'] ?? null, 'Re-enabling must restore the story.' );
+		$this->assert_same( $this->published_story_id, (string) ( $state['story_id'] ?? '' ), 'Restore must reuse the original story ID.' );
+		$story = $this->get_babbel_story( $this->published_story_id );
+		$this->assert_same( 'E2E titel na verwijderen', $story['title'] ?? null, 'Restore must synchronize the current title.' );
+	}
+
+	/**
+	 * Verify scheduled date calculation, rescheduling and future-to-publish recalculation.
+	 */
+	private function test_scheduled_story_lifecycle(): void {
+		$post_id = $this->create_draft( 'E2E gepland', 'Een gepland artikel doorloopt dezelfde betrouwbare asynchrone integratieketen.' );
+		update_post_meta( $post_id, '_zw_knabbel_send_to_babbel', 1 );
+
+		$first_date = $this->future_post_date( 10 );
+		$this->update_post(
+			$post_id,
+			array(
+				'post_status'   => 'publish',
+				'post_date'     => $first_date,
+				'post_date_gmt' => get_gmt_from_date( $first_date ),
+				'edit_date'     => true,
+			)
+		);
+		$this->assert_same( $first_date, get_post( $post_id )->post_date ?? null, 'Scheduled fixture must retain its local publication date.' );
+		$this->assert_same( 'future', get_post_status( $post_id ), 'Scheduled fixture must retain future status before processing.' );
+		$this->assert_same( 1, $this->story_action_count( $post_id ), 'Scheduling must enqueue one worker action.' );
+		$this->run_action_scheduler( self::STORY_HOOK );
+
+		$state    = KnabbelWP\get_story_state( $post_id );
+		$story_id = (string) ( $state['story_id'] ?? '' );
+		$story    = $this->get_babbel_story( $story_id );
+		$dates    = KnabbelWP\calculate_story_dates( $first_date );
+		$this->assert_same( $dates['start_date'], $this->date_only( $story['start_date'] ?? '' ), 'Scheduled start date must use post_date.' );
+		$this->assert_same( $dates['end_date'], $this->date_only( $story['end_date'] ?? '' ), 'Scheduled end date must use post_date.' );
+
+		$second_date = $this->future_post_date( 12 );
+		$this->update_post(
+			$post_id,
+			array(
+				'post_title'    => 'E2E opnieuw gepland',
+				'post_date'     => $second_date,
+				'post_date_gmt' => get_gmt_from_date( $second_date ),
+			)
+		);
+		$story = $this->get_babbel_story( $story_id );
+		$dates = KnabbelWP\calculate_story_dates( $second_date );
+		$this->assert_same( 'E2E opnieuw gepland', $story['title'] ?? null, 'Rescheduling must synchronize the title.' );
+		$this->assert_same( $dates['start_date'], $this->date_only( $story['start_date'] ?? '' ), 'Rescheduling must recalculate story dates.' );
+
+		$published_dates = KnabbelWP\calculate_story_dates( 'now' );
+		$this->update_post(
+			$post_id,
+			array(
+				'post_status'   => 'publish',
+				'post_date'     => current_time( 'mysql' ),
+				'post_date_gmt' => current_time( 'mysql', true ),
+			)
+		);
+		$story = $this->get_babbel_story( $story_id );
+		$this->assert_same(
+			$published_dates['start_date'],
+			$this->date_only( $story['start_date'] ?? '' ),
+			'Publishing a scheduled post must recalculate from now.'
+		);
+		$this->assert_same(
+			$published_dates['end_date'],
+			$this->date_only( $story['end_date'] ?? '' ),
+			'Published scheduled story end date must recalculate from now.'
+		);
+	}
+
+	/**
+	 * Verify pending work is canceled when a future post returns to draft.
+	 */
+	private function test_pending_schedule_cancellation(): void {
+		$title   = 'E2E planning geannuleerd';
+		$post_id = $this->create_draft( $title, 'Deze geplande verwerking wordt geannuleerd voordat een externe story ontstaat.' );
+		update_post_meta( $post_id, '_zw_knabbel_send_to_babbel', 1 );
+		$date = $this->future_post_date( 15 );
+		$this->update_post(
+			$post_id,
+			array(
+				'post_status'   => 'publish',
+				'post_date'     => $date,
+				'post_date_gmt' => get_gmt_from_date( $date ),
+				'edit_date'     => true,
+			)
+		);
+		$this->assert_same( 1, $this->story_action_count( $post_id ), 'Future post must have one pending action before cancellation.' );
+
+		$this->update_post( $post_id, array( 'post_status' => 'draft' ) );
+		$this->assert_same( 0, $this->story_action_count( $post_id ), 'Returning to draft must cancel pending work.' );
+		$this->assert_same( array(), KnabbelWP\get_story_state( $post_id ), 'Cancellation before processing must clear local story state.' );
+		$this->run_action_scheduler( self::STORY_HOOK );
+		$this->assert_same( 0, $this->count_babbel_stories_by_title( $title ), 'Canceled work must never create a Babbel story.' );
+	}
+
+	/**
+	 * Verify post trash hooks soft-delete and untrash restores the same record.
+	 */
+	private function test_trash_and_restore(): void {
+		$post_id  = $this->create_and_process_published_story( 'E2E prullenbak', 'Een gepubliceerd artikel wordt verwijderd en daarna veilig teruggezet.' );
+		$state    = KnabbelWP\get_story_state( $post_id );
+		$story_id = (string) ( $state['story_id'] ?? '' );
+
+		wp_trash_post( $post_id );
+		$state = KnabbelWP\get_story_state( $post_id );
+		$this->assert_same( StoryStatus::Deleted->value, $state['status'] ?? null, 'Trashing must mark the remote story deleted.' );
+		$this->assert_babbel_response_code( 404, 'GET', '/stories/' . $story_id );
+
+		wp_untrash_post( $post_id );
+		$state = KnabbelWP\get_story_state( $post_id );
+		$this->assert_same( StoryStatus::Sent->value, $state['status'] ?? null, 'Untrash must restore the remote story.' );
+		$this->assert_same( $story_id, (string) ( $state['story_id'] ?? '' ), 'Untrash must retain the story ID.' );
+		$this->assert_same( 'E2E prullenbak', $this->get_babbel_story( $story_id )['title'] ?? null, 'Restored trash story must remain readable.' );
+	}
+
+	/**
+	 * Verify retry count and no remote side effect when OpenAI is unavailable.
+	 */
+	private function test_openai_failure(): void {
+		$title = 'E2E OpenAI fout';
+		update_option( 'knabbel_e2e_openai_mode', 'error', false );
+		update_option( 'knabbel_e2e_openai_call_count', 0, false );
+
+		$post_id = $this->create_draft( $title, 'OpenAI faalt deterministisch zodat foutafhandeling en retries aantoonbaar blijven.' );
+		update_post_meta( $post_id, '_zw_knabbel_send_to_babbel', 1 );
+		$this->update_post( $post_id, array( 'post_status' => 'publish' ) );
+		$this->run_action_scheduler( self::STORY_HOOK );
+
+		$state = KnabbelWP\get_story_state( $post_id );
+		$this->assert_same( StoryStatus::Error->value, $state['status'] ?? null, 'OpenAI exhaustion must mark processing as error.' );
+		$this->assert_same( 3, (int) get_option( 'knabbel_e2e_openai_call_count', 0 ), 'OpenAI must be attempted exactly three times.' );
+		$this->assert_same( 0, $this->count_babbel_stories_by_title( $title ), 'OpenAI failure must not create a Babbel story.' );
+
+		update_option( 'knabbel_e2e_openai_mode', 'success', false );
+	}
+
+	/**
+	 * Verify a real Babbel login failure reaches per-story and operator diagnostics.
+	 */
+	private function test_babbel_create_failure(): void {
+		$title = 'E2E Babbel fout';
+		$this->configure_plugin( 'wrong-create-password' );
+
+		$post_id = $this->create_draft( $title, 'Babbel weigert authenticatie en WordPress bewaart een begrensde foutstatus.' );
+		update_post_meta( $post_id, '_zw_knabbel_send_to_babbel', 1 );
+		$this->update_post( $post_id, array( 'post_status' => 'publish' ) );
+		$this->run_action_scheduler( self::STORY_HOOK );
+
+		$state = KnabbelWP\get_story_state( $post_id );
+		$this->assert_same( StoryStatus::Error->value, $state['status'] ?? null, 'Babbel create failure must mark lifecycle error.' );
+		$this->assert_same( 'create', $state['last_sync_error']['operation'] ?? null, 'Babbel create failure must identify the operation.' );
+		$this->assert_same( 0, $this->count_babbel_stories_by_title( $title ), 'Rejected authentication must not create a story.' );
+		$error_json = wp_json_encode( get_option( 'knabbel_recent_errors', array() ) );
+		$this->assert_false(
+			is_string( $error_json ) && str_contains( $error_json, 'wrong-create-password' ),
+			'Recent errors must exclude failed credentials.'
+		);
+
+		$this->configure_plugin();
+	}
+
+	/**
+	 * Verify the recurring integration learns edited remote text and clears cache when disabled.
+	 */
+	private function test_few_shot_sync(): void {
+		$edited_text = 'Dit is de aantoonbaar door een redacteur aangepaste radiospreektekst.';
+		$response    = $this->babbel_request(
+			'PUT',
+			'/stories/' . $this->published_story_id,
+			array(
+				'text'   => $edited_text,
+				'status' => 'active',
+			)
+		);
+		$this->assert_same( 200, wp_remote_retrieve_response_code( $response ), 'The fixture story must be editable in Babbel.' );
+
+		$settings                   = get_option( 'knabbel_settings', array() );
+		$settings['few_shot_count'] = 1;
+		update_option( 'knabbel_settings', $settings );
+		as_enqueue_async_action( self::FEW_SHOT_HOOK, array(), self::ACTION_GROUP );
+		$this->run_action_scheduler( self::FEW_SHOT_HOOK );
+
+		$examples = get_option( 'knabbel_few_shot_examples', array() );
+		$this->assert_same( 1, count( $examples ), 'Few-shot sync must cache the configured number of examples.' );
+		$this->assert_same( $edited_text, $examples[0]['output'] ?? null, 'Few-shot output must use editor-corrected Babbel text.' );
+		$this->assert_same(
+			wp_strip_all_tags( get_post_field( 'post_content', $this->published_post_id ) ),
+			$examples[0]['input'] ?? null,
+			'Few-shot input must use current WordPress content.'
+		);
+
+		$settings['few_shot_count'] = 0;
+		update_option( 'knabbel_settings', $settings );
+		as_enqueue_async_action( self::FEW_SHOT_HOOK, array(), self::ACTION_GROUP );
+		$this->run_action_scheduler( self::FEW_SHOT_HOOK );
+		$this->assert_false( false !== get_option( 'knabbel_few_shot_examples', false ), 'Disabling few-shot must remove cached examples.' );
+	}
+
+	/**
+	 * Verify plugin lifecycle cleanup after all functional scenarios.
+	 */
+	private function test_deactivation_cleanup(): void {
+		$this->configure_plugin();
+		$result = KnabbelWP\babbel_test_connection();
+		$this->assert_true( $result['success'], 'Precondition: session cache must exist before deactivation.' );
+		update_option(
+			'knabbel_few_shot_examples',
+			array(
+				array(
+					'input'  => 'x',
+					'output' => 'y',
+				),
+			),
+			false
+		);
+
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		deactivate_plugins( 'zw-knabbel-wp/zw-knabbel-wp.php' );
+
+		$this->assert_false( is_plugin_active( 'zw-knabbel-wp/zw-knabbel-wp.php' ), 'The plugin must be inactive after deactivation.' );
+		$this->assert_same( 0, $this->action_count( self::STORY_HOOK, ActionScheduler_Store::STATUS_PENDING ), 'Deactivation must clear story actions.' );
+		$this->assert_same(
+			0,
+			$this->action_count( self::FEW_SHOT_HOOK, ActionScheduler_Store::STATUS_PENDING ),
+			'Deactivation must clear the recurring few-shot action.'
+		);
+		$this->assert_false( false !== get_transient( $this->plugin_session_cache_key() ), 'Deactivation must clear Babbel sessions.' );
+		$this->assert_false( false !== get_option( 'knabbel_few_shot_examples', false ), 'Deactivation must clear few-shot data.' );
+	}
+
+	/**
+	 * Create and process one published story.
+	 *
+	 * @param string $title   Post title.
+	 * @param string $content Post content.
+	 * @return int Post ID.
+	 * @throws RuntimeException When WordPress cannot create the post.
+	 */
+	private function create_and_process_published_story( string $title, string $content ): int {
+		$post_id = $this->create_draft( $title, $content );
+		update_post_meta( $post_id, '_zw_knabbel_send_to_babbel', 1 );
+		$this->update_post( $post_id, array( 'post_status' => 'publish' ) );
+		$this->run_action_scheduler( self::STORY_HOOK );
+		$this->assert_same( StoryStatus::Sent->value, KnabbelWP\get_story_state( $post_id )['status'] ?? null, 'Published fixture must reach sent state.' );
+
+		return $post_id;
+	}
+
+	/**
+	 * Create a draft post and fail on WordPress errors.
+	 *
+	 * @param string $title   Post title.
+	 * @param string $content Post content.
+	 * @return int Post ID.
+	 * @throws RuntimeException When WordPress cannot create the post.
+	 */
+	private function create_draft( string $title, string $content ): int {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'post',
+				'post_status'  => 'draft',
+				'post_title'   => $title,
+				'post_content' => $content,
+			),
+			true
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			throw new RuntimeException( 'Could not create test post: ' . $post_id->get_error_message() );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Update a post and fail on WordPress errors.
+	 *
+	 * @param int                  $post_id Post ID.
+	 * @param array<string, mixed> $updates Post fields.
+	 * @throws RuntimeException When WordPress cannot update the post.
+	 */
+	private function update_post( int $post_id, array $updates ): void {
+		$result = wp_update_post( array_merge( array( 'ID' => $post_id ), $updates ), true );
+		if ( is_wp_error( $result ) ) {
+			throw new RuntimeException( 'Could not update test post: ' . $result->get_error_message() );
+		}
+	}
+
+	/**
+	 * Run due actions through Action Scheduler's queue runner.
+	 *
+	 * @param string $hook Hook to execute.
+	 * @throws RuntimeException When an action does not complete successfully.
+	 */
+	private function run_action_scheduler( string $hook ): void {
+		$ids = as_get_scheduled_actions(
+			array(
+				'hook'         => $hook,
+				'group'        => self::ACTION_GROUP,
+				'status'       => ActionScheduler_Store::STATUS_PENDING,
+				'date'         => time(),
+				'date_compare' => '<=',
+				'per_page'     => -1,
+			),
+			'ids'
+		);
+
+		foreach ( $ids as $id ) {
+			ActionScheduler::runner()->process_action( $id, 'Knabbel E2E' );
+			$status = ActionScheduler::store()->get_status( $id );
+
+			if ( ActionScheduler_Store::STATUS_COMPLETE !== $status ) {
+				throw new RuntimeException( sprintf( 'Action Scheduler action %d finished with status %s.', $id, $status ) );
+			}
+		}
+	}
+
+	/**
+	 * Count scheduled actions by hook and status.
+	 *
+	 * @param string $hook   Action hook.
+	 * @param string $status Action Scheduler status.
+	 * @return int Action count.
+	 */
+	private function action_count( string $hook, string $status ): int {
+		$ids = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'group'    => self::ACTION_GROUP,
+				'status'   => $status,
+				'per_page' => -1,
+			),
+			'ids'
+		);
+
+		return count( $ids );
+	}
+
+	/**
+	 * Count pending story actions for one post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return int Action count.
+	 */
+	private function story_action_count( int $post_id ): int {
+		$ids = as_get_scheduled_actions(
+			array(
+				'hook'     => self::STORY_HOOK,
+				'args'     => array( 'post_id' => $post_id ),
+				'group'    => self::ACTION_GROUP,
+				'status'   => ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => -1,
+			),
+			'ids'
+		);
+
+		return count( $ids );
+	}
+
+	/**
+	 * Issue an authenticated request using an independent test client.
+	 *
+	 * @param string                    $method HTTP method.
+	 * @param string                    $path   API path below /api/v1.
+	 * @param array<string, mixed>|null $body   Optional JSON body.
+	 * @return array<string, mixed> WordPress HTTP response.
+	 * @throws RuntimeException When the HTTP request fails.
+	 */
+	private function babbel_request( string $method, string $path, ?array $body = null ): array {
+		if ( array() === $this->babbel_cookies ) {
+			$this->babbel_login();
+		}
+
+		$args = array(
+			'method'  => $method,
+			'timeout' => 30,
+			'cookies' => $this->babbel_cookies,
+		);
+
+		if ( null !== $body ) {
+			$args['headers'] = array( 'Content-Type' => 'application/json' );
+			$args['body']    = wp_json_encode( $body );
+		}
+
+		$response = wp_remote_request( self::BABBEL_BASE_URL . $path, $args );
+		if ( is_wp_error( $response ) ) {
+			throw new RuntimeException( 'Independent Babbel request failed: ' . $response->get_error_message() );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Authenticate the independent verification client.
+	 *
+	 * @throws RuntimeException When the HTTP request fails.
+	 */
+	private function babbel_login(): void {
+		$response = wp_remote_post(
+			self::BABBEL_BASE_URL . '/sessions',
+			array(
+				'headers' => array( 'Content-Type' => 'application/json' ),
+				'body'    => wp_json_encode(
+					array(
+						'username' => 'admin',
+						'password' => 'admin',
+					)
+				),
+				'timeout' => 30,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			throw new RuntimeException( 'Independent Babbel login failed: ' . $response->get_error_message() );
+		}
+
+		$this->assert_same( 201, wp_remote_retrieve_response_code( $response ), 'Independent Babbel client must authenticate.' );
+		$this->babbel_cookies = wp_remote_retrieve_cookies( $response );
+		$this->assert_not_empty( $this->babbel_cookies, 'Independent Babbel login must return a cookie.' );
+	}
+
+	/**
+	 * Fetch and decode one Babbel story.
+	 *
+	 * @param string $story_id Story ID.
+	 * @return array<string, mixed> Story response.
+	 */
+	private function get_babbel_story( string $story_id ): array {
+		$this->assert_not_empty( $story_id, 'Story ID is required for remote verification.' );
+		$response = $this->babbel_request( 'GET', '/stories/' . rawurlencode( $story_id ) );
+		$this->assert_same( 200, wp_remote_retrieve_response_code( $response ), 'Expected Babbel story to be readable.' );
+		$decoded = json_decode( wp_remote_retrieve_body( $response ), true, 512, JSON_THROW_ON_ERROR );
+		$this->assert_true( is_array( $decoded ), 'Babbel story response must decode to an object.' );
+
+		return $decoded;
+	}
+
+	/**
+	 * Count visible Babbel stories with an exact title.
+	 *
+	 * @param string $title Story title.
+	 * @return int Matching count.
+	 */
+	private function count_babbel_stories_by_title( string $title ): int {
+		$path     = '/stories?' . http_build_query(
+			array(
+				'filter' => array( 'title' => $title ),
+				'limit'  => 100,
+			)
+		);
+		$response = $this->babbel_request( 'GET', $path );
+		$this->assert_same( 200, wp_remote_retrieve_response_code( $response ), 'Babbel story list must be readable.' );
+		$decoded = json_decode( wp_remote_retrieve_body( $response ), true, 512, JSON_THROW_ON_ERROR );
+		$stories = is_array( $decoded['data'] ?? null ) ? $decoded['data'] : array();
+
+		return count(
+			array_filter(
+				$stories,
+				static fn( array $story ): bool => ( $story['title'] ?? null ) === $title
+			)
+		);
+	}
+
+	/**
+	 * Assert a response status without decoding the body.
+	 *
+	 * @param int    $expected Expected status.
+	 * @param string $method   HTTP method.
+	 * @param string $path     API path.
+	 */
+	private function assert_babbel_response_code( int $expected, string $method, string $path ): void {
+		$response = $this->babbel_request( $method, $path );
+		$this->assert_same(
+			$expected,
+			wp_remote_retrieve_response_code( $response ),
+			sprintf( 'Babbel %s %s returned an unexpected status.', $method, $path )
+		);
+	}
+
+	/**
+	 * Build the plugin's session transient key.
+	 *
+	 * @return string Cache key.
+	 */
+	private function plugin_session_cache_key(): string {
+		$credentials = KnabbelWP\babbel_get_credentials();
+		return 'knabbel_session_' . md5( $credentials['base_url'] . $credentials['username'] );
+	}
+
+	/**
+	 * Return a stable future local timestamp.
+	 *
+	 * @param int $days Days from now.
+	 * @return string MySQL datetime.
+	 */
+	private function future_post_date( int $days ): string {
+		return ( new DateTimeImmutable( 'now', wp_timezone() ) )->modify( sprintf( '+%d days', $days ) )->setTime( 12, 0 )->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Normalize an API date or datetime to Y-m-d.
+	 *
+	 * @param mixed $value API value.
+	 * @return string Date portion.
+	 */
+	private function date_only( mixed $value ): string {
+		return is_string( $value ) ? substr( $value, 0, 10 ) : '';
+	}
+
+	/**
+	 * Assert strict equality.
+	 *
+	 * @param mixed  $expected Expected value.
+	 * @param mixed  $actual   Actual value.
+	 * @param string $message  Failure message.
+	 * @throws RuntimeException When the values differ.
+	 */
+	private function assert_same( mixed $expected, mixed $actual, string $message ): void {
+		++$this->assertion_count;
+		if ( $expected !== $actual ) {
+			throw new RuntimeException( sprintf( '%s Expected %s, got %s.', $message, $this->describe( $expected ), $this->describe( $actual ) ) );
+		}
+	}
+
+	/**
+	 * Assert values are not strictly equal.
+	 *
+	 * @param mixed  $unexpected Unexpected value.
+	 * @param mixed  $actual     Actual value.
+	 * @param string $message    Failure message.
+	 * @throws RuntimeException When the values are equal.
+	 */
+	private function assert_not_same( mixed $unexpected, mixed $actual, string $message ): void {
+		++$this->assertion_count;
+		if ( $unexpected === $actual ) {
+			throw new RuntimeException( $message );
+		}
+	}
+
+	/**
+	 * Assert a truthy condition.
+	 *
+	 * @param bool   $condition Condition.
+	 * @param string $message   Failure message.
+	 * @throws RuntimeException When the condition is false.
+	 */
+	private function assert_true( bool $condition, string $message ): void {
+		++$this->assertion_count;
+		if ( ! $condition ) {
+			throw new RuntimeException( $message );
+		}
+	}
+
+	/**
+	 * Assert a false condition.
+	 *
+	 * @param bool   $condition Condition.
+	 * @param string $message   Failure message.
+	 */
+	private function assert_false( bool $condition, string $message ): void {
+		$this->assert_true( ! $condition, $message );
+	}
+
+	/**
+	 * Assert a non-empty value.
+	 *
+	 * @param mixed  $value   Value.
+	 * @param string $message Failure message.
+	 * @throws RuntimeException When the value is empty.
+	 */
+	private function assert_not_empty( mixed $value, string $message ): void {
+		++$this->assertion_count;
+		if ( empty( $value ) ) {
+			throw new RuntimeException( $message );
+		}
+	}
+
+	/**
+	 * Assert one string contains another.
+	 *
+	 * @param string $needle  Required substring.
+	 * @param string $haystack Searched string.
+	 * @param string $message Failure message.
+	 */
+	private function assert_string_contains( string $needle, string $haystack, string $message ): void {
+		$this->assert_true( str_contains( $haystack, $needle ), $message );
+	}
+
+	/**
+	 * Render a compact diagnostic value.
+	 *
+	 * @param mixed $value Value.
+	 * @return string Description.
+	 */
+	private function describe( mixed $value ): string {
+		$encoded = wp_json_encode( $value );
+		return false === $encoded ? get_debug_type( $value ) : $encoded;
+	}
+}
+
+( new Knabbel_E2E_Suite() )->run();

--- a/uninstall.php
+++ b/uninstall.php
@@ -14,14 +14,9 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-global $wpdb;
-
 // Clean up transients (session cache).
-$wpdb->query(
-	"DELETE FROM {$wpdb->options}
-	WHERE option_name LIKE '_transient_knabbel_session_%'
-	OR option_name LIKE '_transient_timeout_knabbel_session_%'"
-);
+require_once __DIR__ . '/includes/babbel-api.php';
+KnabbelWP\babbel_cleanup_sessions();
 
 // Clean up temporary options.
 delete_option( 'knabbel_recent_errors' );


### PR DESCRIPTION
## Summary

- add an isolated Docker E2E environment with WordPress, MySQL, the real Babbel API, Action Scheduler, and a deterministic OpenAI stub
- cover 11 synchronization, scheduling, recovery, error-handling, few-shot, and deactivation scenarios
- invalidate WordPress option and object caches when Babbel sessions are cleaned up
- run the E2E suite and ShellCheck in dedicated GitHub Actions workflows
- include the E2E PHP harness in PHPCS coverage

## Testing

- BABBEL_PATH=../zwfm-babbel tests/e2e/run.sh (11 scenarios, 122 assertions)
- vendor/bin/phpcs
- php -d memory_limit=512M vendor/bin/phpstan analyse
- npm run lint
- shellcheck tests/e2e/run.sh
- actionlint .github/workflows/*.yml
- yamllint on the new workflows and Compose configuration
- docker compose config
- composer validate --no-check-publish
- PHP syntax checks
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of expired session data by deleting matching transients through WordPress’s standard option deletion path (including during uninstall).
* **Tests**
  * Added a WordPress↔Babbel end-to-end regression suite using Docker Compose, a local runner script, deterministic OpenAI HTTP stubbing, and automatic failure artifact capture.
* **Chores**
  * Added CI workflows for E2E testing and ShellCheck, extended code scanning to cover E2E tests, and updated ignore rules for E2E artifacts/docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->