### PR TITLE
test: add Playwright editor workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     labels: ["dependencies", "composer"]
     rebase-strategy: "auto"
 
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -19,6 +19,16 @@ updates:
       time: "07:10"
       timezone: "Europe/Amsterdam"
     open-pull-requests-limit: 10
-    labels: ["dependencies", "github-actions"]
+    labels: ["dependencies", "npm"]
     rebase-strategy: "auto"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:20"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "github-actions"]
+    rebase-strategy: "auto"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,10 @@ name: Babbel E2E
       - '**/*.php'
       - 'composer.json'
       - 'composer.lock'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'playwright.config.ts'
+      - 'tests/playwright/**'
       - 'tests/e2e/**'
       - '.github/workflows/e2e.yml'
   pull_request:
@@ -15,6 +19,10 @@ name: Babbel E2E
       - '**/*.php'
       - 'composer.json'
       - 'composer.lock'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'playwright.config.ts'
+      - 'tests/playwright/**'
       - 'tests/e2e/**'
       - '.github/workflows/e2e.yml'
   schedule:
@@ -56,9 +64,23 @@ jobs:
           coverage: none
           tools: composer:v2
 
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
       - name: Install plugin dependencies
         working-directory: zw-knabbel-wp
         run: composer install --no-dev --no-interaction --no-progress --prefer-dist
+
+      - name: Install browser test dependencies
+        working-directory: zw-knabbel-wp
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: zw-knabbel-wp
+        run: npx playwright install --with-deps chromium
 
       - name: Run E2E suite
         working-directory: zw-knabbel-wp
@@ -71,6 +93,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: babbel-e2e-logs
-          path: zw-knabbel-wp/tests/e2e/artifacts/
+          path: |
+            zw-knabbel-wp/tests/e2e/artifacts/
+            zw-knabbel-wp/playwright-report/
+            zw-knabbel-wp/test-results/
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
+          cache-dependency-path: zw-knabbel-wp/package-lock.json
 
       - name: Install plugin dependencies
         working-directory: zw-knabbel-wp

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,6 +79,12 @@ jobs:
         working-directory: zw-knabbel-wp
         run: npm ci
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('zw-knabbel-wp/package-lock.json') }}
+
       - name: Install Chromium
         working-directory: zw-knabbel-wp
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,7 @@ name: Babbel E2E
     branches: [main]
     paths:
       - '**/*.php'
+      - 'assets/**'
       - 'composer.json'
       - 'composer.lock'
       - 'package.json'
@@ -15,16 +16,6 @@ name: Babbel E2E
       - 'tests/e2e/**'
       - '.github/workflows/e2e.yml'
   pull_request:
-    paths:
-      - '**/*.php'
-      - 'composer.json'
-      - 'composer.lock'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'playwright.config.ts'
-      - 'tests/playwright/**'
-      - 'tests/e2e/**'
-      - '.github/workflows/e2e.yml'
   schedule:
     - cron: '30 4 * * 0'
   workflow_dispatch:
@@ -80,7 +71,7 @@ jobs:
         run: npm ci
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('zw-knabbel-wp/package-lock.json') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,7 @@ name: Babbel E2E
       - 'package.json'
       - 'package-lock.json'
       - 'playwright.config.ts'
+      - 'tsconfig.json'
       - 'tests/playwright/**'
       - 'tests/e2e/**'
       - '.github/workflows/e2e.yml'
@@ -86,8 +87,8 @@ jobs:
           BABBEL_PATH: ${{ github.workspace }}/zwfm-babbel
         run: tests/e2e/run.sh
 
-      - name: Upload failure logs
-        if: failure()
+      - name: Upload E2E artifacts
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: babbel-e2e-logs
@@ -95,5 +96,5 @@ jobs:
             zw-knabbel-wp/tests/e2e/artifacts/
             zw-knabbel-wp/playwright-report/
             zw-knabbel-wp/test-results/
-          if-no-files-found: ignore
+          if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,14 +72,24 @@ jobs:
         run: npm ci
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('zw-knabbel-wp/package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-
+
+      # OS packages live outside the cached directory and the runner is ephemeral,
+      # so system dependencies must be installed on every run. Only the browser
+      # binaries themselves come from the cache.
+      - name: Install Chromium system dependencies
+        working-directory: zw-knabbel-wp
+        run: npx playwright install-deps chromium
 
       - name: Install Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: zw-knabbel-wp
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Run E2E suite
         working-directory: zw-knabbel-wp

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -15,6 +15,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -11,14 +11,8 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'biome.json'
+      - 'tsconfig.json'
   pull_request:
-    paths:
-      - '**/*.js'
-      - '**/*.ts'
-      - '**/*.css'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'biome.json'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,15 +14,6 @@ on:
       - 'phpstan-bootstrap.php'
       - 'languages/**'
   pull_request:
-    paths:
-      - '**/*.php'
-      - 'composer.json'
-      - 'composer.lock'
-      - 'phpcs.xml'
-      - 'phpcs.xml.dist'
-      - 'phpstan.neon'
-      - 'phpstan-bootstrap.php'
-      - 'languages/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/shell-quality.yml
+++ b/.github/workflows/shell-quality.yml
@@ -7,8 +7,6 @@ name: Shell Quality
     paths:
       - '**.sh'
   pull_request:
-    paths:
-      - '**.sh'
   workflow_dispatch:
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 *.md
 !**/README.md
 /tests/e2e/artifacts/
+/playwright-report/
+/test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 *.md
 !**/README.md
 /tests/e2e/artifacts/
+/playwright/.auth/
 /playwright-report/
 /test-results/

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -36,7 +36,8 @@
                     : '<svg width="16" height="16" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"/></svg>';
                 result.className = `knabbel-test-result ${statusClass}`;
                 result.innerHTML = `${icon} ${data.data}`;
-            } catch {
+            } catch (error) {
+                console.error('Knabbel API test failed:', error);
                 result.className = 'knabbel-test-result error';
                 result.innerHTML = knabbel_admin.error_text;
             } finally {

--- a/biome.json
+++ b/biome.json
@@ -32,6 +32,8 @@
         "includes": [
             "**/assets/**/*.js",
             "**/assets/**/*.css",
+            "playwright.config.ts",
+            "tests/playwright/**/*.ts",
             "!**/vendor/**",
             "!**/node_modules/**"
         ]

--- a/biome.json
+++ b/biome.json
@@ -34,8 +34,8 @@
             "**/assets/**/*.css",
             "playwright.config.ts",
             "tests/playwright/**/*.ts",
-            "!**/vendor/**",
-            "!**/node_modules/**"
+            "!**/vendor",
+            "!**/node_modules"
         ]
     }
 }

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -676,12 +676,15 @@ function render_articles_overview(): void {
 
 	$query = new \WP_Query(
 		array(
-			'post_type'      => 'post',
-			'post_status'    => 'any',
-			'posts_per_page' => 25,
-			'orderby'        => 'date',
-			'order'          => 'DESC',
-			'meta_query'     => array(
+			'post_type'              => 'post',
+			'post_status'            => 'any',
+			'posts_per_page'         => 25,
+			'orderby'                => 'date',
+			'order'                  => 'DESC',
+			'no_found_rows'          => true,
+			'update_post_term_cache' => false,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded admin-only query; no pagination and post meta is primed for 25 results.
+			'meta_query'             => array(
 				array(
 					'key'     => '_zw_knabbel_story_state',
 					'compare' => 'EXISTS',

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -763,6 +763,7 @@ function babbel_fetch_recent_stories( int $limit = 20 ): array|\WP_Error {
 function babbel_cleanup_sessions(): void {
 	global $wpdb;
 
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- No cached API supports prefix transient lookup.
 	$option_names = $wpdb->get_col(
 		$wpdb->prepare(
 			'SELECT option_name FROM ' . $wpdb->options . ' WHERE option_name LIKE %s',

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -763,7 +763,7 @@ function babbel_fetch_recent_stories( int $limit = 20 ): array|\WP_Error {
 function babbel_cleanup_sessions(): void {
 	global $wpdb;
 
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- No cached API supports prefix transient lookup.
+	// A direct query is required because no core API enumerates transients by prefix.
 	$option_names = $wpdb->get_col(
 		$wpdb->prepare(
 			'SELECT option_name FROM ' . $wpdb->options . ' WHERE option_name LIKE %s',

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -763,7 +763,7 @@ function babbel_fetch_recent_stories( int $limit = 20 ): array|\WP_Error {
 function babbel_cleanup_sessions(): void {
 	global $wpdb;
 
-	// A direct query is required because no core API enumerates transients by prefix.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- No cached core API supports prefix transient lookup.
 	$option_names = $wpdb->get_col(
 		$wpdb->prepare(
 			'SELECT option_name FROM ' . $wpdb->options . ' WHERE option_name LIKE %s',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "zw-knabbel-wp",
       "devDependencies": {
         "@biomejs/biome": "^2.3.0",
-        "@playwright/test": "^1.61.1"
+        "@playwright/test": "^1.61.1",
+        "@types/node": "^24.0.0",
+        "typescript": "^7.0.2"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -190,6 +192,356 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -236,6 +588,48 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "": {
       "name": "zw-knabbel-wp",
       "devDependencies": {
-        "@biomejs/biome": "^2.3.0"
+        "@biomejs/biome": "^2.3.0",
+        "@playwright/test": "^1.61.1"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -171,6 +172,69 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "private": true,
   "description": "WordPress plugin for Babbel API integration",
   "scripts": {
-    "lint": "biome check assets/",
-    "lint:fix": "biome check --write assets/",
+    "lint": "biome check assets/ && biome lint playwright.config.ts tests/playwright/ && tsc --noEmit",
+    "lint:fix": "biome check --write assets/ && biome lint --write playwright.config.ts tests/playwright/ && tsc --noEmit",
     "format": "biome format --write assets/",
     "test:e2e:browser": "playwright test"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.0",
-    "@playwright/test": "^1.61.1"
+    "@playwright/test": "^1.61.1",
+    "@types/node": "^24.0.0",
+    "typescript": "^7.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "lint": "biome check assets/",
     "lint:fix": "biome check --write assets/",
-    "format": "biome format --write assets/"
+    "format": "biome format --write assets/",
+    "test:e2e:browser": "playwright test"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.0"
+    "@biomejs/biome": "^2.3.0",
+    "@playwright/test": "^1.61.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "description": "WordPress plugin for Babbel API integration",
   "scripts": {
-    "lint": "biome check assets/ && biome lint playwright.config.ts tests/playwright/ && tsc --noEmit",
-    "lint:fix": "biome check --write assets/ && biome lint --write playwright.config.ts tests/playwright/ && tsc --noEmit",
-    "format": "biome format --write assets/",
+    "lint": "biome check assets/ playwright.config.ts tests/playwright/ && tsc --noEmit",
+    "lint:fix": "biome check --write assets/ playwright.config.ts tests/playwright/ && tsc --noEmit",
+    "format": "biome format --write assets/ playwright.config.ts tests/playwright/",
     "test:e2e:browser": "playwright test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "private": true,
   "description": "WordPress plugin for Babbel API integration",
   "scripts": {
-    "lint": "biome check assets/ playwright.config.ts tests/playwright/ && tsc --noEmit",
-    "lint:fix": "biome check --write assets/ playwright.config.ts tests/playwright/ && tsc --noEmit",
+    "lint": "biome check assets/ playwright.config.ts tests/playwright/ && npm run typecheck",
+    "lint:fix": "biome check --write assets/ playwright.config.ts tests/playwright/",
+    "typecheck": "tsc",
     "format": "biome format --write assets/ playwright.config.ts tests/playwright/",
     "test:e2e:browser": "playwright test"
   },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -52,9 +52,9 @@
         <exclude-pattern>tests/e2e/suite.php</exclude-pattern>
     </rule>
 
-    <!-- Exception messages are CLI diagnostics and are never rendered as HTML. -->
+    <!-- E2E exception messages are test diagnostics and are never rendered as HTML. -->
     <rule ref="WordPress.Security.EscapeOutput.ExceptionNotEscaped">
-        <exclude-pattern>tests/e2e/suite.php</exclude-pattern>
+        <exclude-pattern>tests/e2e/*</exclude-pattern>
     </rule>
 
     <exclude-pattern>vendor/*</exclude-pattern>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,12 +3,13 @@ import { defineConfig, devices } from '@playwright/test';
 const baseURL =
 	process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8080';
 
+export const STORAGE_STATE = 'test-results/.auth/admin.json';
+
 export default defineConfig({
 	testDir: './tests/playwright',
-	fullyParallel: false,
 	workers: 1,
 	forbidOnly: Boolean(process.env.CI),
-	retries: process.env.CI ? 2 : 0,
+	retries: process.env.CI ? 1 : 0,
 	timeout: 60_000,
 	expect: { timeout: 15_000 },
 	reporter: process.env.CI ? [['github'], ['html']] : 'list',
@@ -19,8 +20,13 @@ export default defineConfig({
 	},
 	projects: [
 		{
+			name: 'setup',
+			testMatch: /auth\.setup\.ts/,
+		},
+		{
 			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] },
+			use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+			dependencies: ['setup'],
 		},
 	],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL =
+	process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8080';
+
+export default defineConfig({
+	testDir: './tests/playwright',
+	fullyParallel: false,
+	workers: 1,
+	forbidOnly: Boolean(process.env.CI),
+	retries: process.env.CI ? 2 : 0,
+	timeout: 60_000,
+	expect: { timeout: 15_000 },
+	reporter: process.env.CI ? [['github'], ['html']] : 'list',
+	use: {
+		baseURL,
+		screenshot: 'only-on-failure',
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,8 +12,9 @@ export default defineConfig({
     // The serial editor flow shares one WordPress post and Babbel story.
     workers: 1,
     forbidOnly: Boolean(process.env.CI),
-    retries: process.env.CI ? 1 : 0,
-    failOnFlakyTests: Boolean(process.env.CI),
+    // No retries: the suite is deterministic, and a serial retry would re-run the
+    // whole group against state the failed attempt already mutated.
+    retries: 0,
     timeout: 60_000,
     expect: { timeout: 15_000 },
     reporter: process.env.CI ? [['github'], ['html']] : 'list',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,32 +1,36 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL =
-	process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:8080';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL;
+if (!baseURL) {
+    throw new Error('PLAYWRIGHT_BASE_URL is required.');
+}
 
-export const STORAGE_STATE = 'test-results/.auth/admin.json';
+export const STORAGE_STATE = 'playwright/.auth/admin.json';
 
 export default defineConfig({
-	testDir: './tests/playwright',
-	workers: 1,
-	forbidOnly: Boolean(process.env.CI),
-	retries: process.env.CI ? 1 : 0,
-	timeout: 60_000,
-	expect: { timeout: 15_000 },
-	reporter: process.env.CI ? [['github'], ['html']] : 'list',
-	use: {
-		baseURL,
-		screenshot: 'only-on-failure',
-		trace: 'on-first-retry',
-	},
-	projects: [
-		{
-			name: 'setup',
-			testMatch: /auth\.setup\.ts/,
-		},
-		{
-			name: 'chromium',
-			use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
-			dependencies: ['setup'],
-		},
-	],
+    testDir: './tests/playwright',
+    // The serial editor flow shares one WordPress post and Babbel story.
+    workers: 1,
+    forbidOnly: Boolean(process.env.CI),
+    retries: process.env.CI ? 1 : 0,
+    failOnFlakyTests: Boolean(process.env.CI),
+    timeout: 60_000,
+    expect: { timeout: 15_000 },
+    reporter: process.env.CI ? [['github'], ['html']] : 'list',
+    use: {
+        baseURL,
+        screenshot: 'only-on-failure',
+        trace: 'retain-on-failure',
+    },
+    projects: [
+        {
+            name: 'setup',
+            testMatch: /auth\.setup\.ts/,
+        },
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+            dependencies: ['setup'],
+        },
+    ],
 });

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,12 +11,15 @@ Prerequisites:
 
 - Docker with Docker Compose
 - Composer dependencies installed in this plugin repository
+- Node.js dependencies and the Playwright Chromium browser installed
 - A local `zwfm-babbel` checkout
 
 From the plugin root:
 
 ```bash
 composer install
+npm install
+npx playwright install chromium
 BABBEL_PATH=../zwfm-babbel tests/e2e/run.sh
 ```
 
@@ -29,5 +32,12 @@ project, removes it after the run, and writes combined container logs to
 
 The scenario catalog (E2E-001 through E2E-011) lives in the `run()` method of
 `suite.php`; the runner prints each scenario ID and title during execution.
+
+Before the PHP scenarios, Playwright drives the real WordPress admin UI in
+Chromium. The browser coverage saves and tests plugin settings, publishes and
+edits a post, disables and restores Babbel synchronization, cancels a scheduled
+post, and trashes and restores a sent post. The browser suite uses the classic
+WordPress post editor to keep the plugin-owned metabox flow deterministic; the
+test-only editor filter and queue controls are loaded as an isolated MU plugin.
 
 The credentials in the Compose file and suite are isolated test fixtures only.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -19,7 +19,7 @@ From the plugin root:
 ```bash
 composer install
 npm install
-npx playwright install chromium
+npx playwright install --with-deps chromium
 BABBEL_PATH=../zwfm-babbel tests/e2e/run.sh
 ```
 
@@ -37,7 +37,13 @@ Before the PHP scenarios, Playwright drives the real WordPress admin UI in
 Chromium. The browser coverage saves and tests plugin settings, publishes and
 edits a post, disables and restores Babbel synchronization, cancels a scheduled
 post, and trashes and restores a sent post. The browser suite uses the classic
-WordPress post editor to keep the plugin-owned metabox flow deterministic; the
-test-only editor filter and queue controls are loaded as an isolated MU plugin.
+WordPress post editor to keep the plugin-owned metabox flow deterministic. The
+PHP and browser suites share test-only editor and queue controls loaded as an MU
+plugin.
+
+The runner invokes `npm run test:e2e:browser` with the discovered WordPress and
+Babbel URLs. To run Playwright against already-running services, set
+`PLAYWRIGHT_BASE_URL` to the WordPress origin and `PLAYWRIGHT_BABBEL_URL` to the
+Babbel `/api/v1` URL before running that npm command.
 
 The credentials in the Compose file and suite are isolated test fixtures only.

--- a/tests/e2e/compose.yml
+++ b/tests/e2e/compose.yml
@@ -37,6 +37,8 @@ services:
         define( 'WP_DEBUG_LOG', true );
         define( 'DISABLE_WP_CRON', true );
     volumes: *wordpress-volumes
+    ports:
+      - "127.0.0.1::80"
     depends_on:
       wordpress-db:
         condition: service_healthy
@@ -92,6 +94,8 @@ services:
     depends_on:
       babbel-db:
         condition: service_healthy
+    ports:
+      - "127.0.0.1::8080"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
       interval: 2s

--- a/tests/e2e/compose.yml
+++ b/tests/e2e/compose.yml
@@ -4,6 +4,11 @@ x-wordpress-env: &wordpress-env
   WORDPRESS_DB_NAME: wordpress
   WORDPRESS_DB_USER: wordpress
   WORDPRESS_DB_PASSWORD: wordpress
+  WORDPRESS_DEBUG: "1"
+  WORDPRESS_CONFIG_EXTRA: |
+    define( 'WP_ENVIRONMENT_TYPE', 'local' );
+    define( 'WP_DEBUG_LOG', true );
+    define( 'DISABLE_WP_CRON', true );
 
 x-wordpress-volumes: &wordpress-volumes
   - wordpress-data:/var/www/html
@@ -31,11 +36,6 @@ services:
     image: wordpress:7.0.1-php8.3-apache
     environment:
       <<: *wordpress-env
-      WORDPRESS_DEBUG: "1"
-      WORDPRESS_CONFIG_EXTRA: |
-        define( 'WP_ENVIRONMENT_TYPE', 'local' );
-        define( 'WP_DEBUG_LOG', true );
-        define( 'DISABLE_WP_CRON', true );
     volumes: *wordpress-volumes
     ports:
       - "127.0.0.1::80"

--- a/tests/e2e/mu-plugins/knabbel-e2e-control.php
+++ b/tests/e2e/mu-plugins/knabbel-e2e-control.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Plugin Name: Knabbel E2E Browser Control
+ * Description: Deterministic editor and Action Scheduler controls for browser E2E tests.
+ *
+ * @package KnabbelWP
+ */
+
+declare(strict_types=1);
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_filter(
+	'use_block_editor_for_post_type',
+	static fn( bool $use_block_editor, string $post_type ): bool => 'post' === $post_type ? false : $use_block_editor,
+	10,
+	2
+);
+
+add_action(
+	'add_meta_boxes_post',
+	static function (): void {
+		add_meta_box(
+			'acf-group_5f21a05a18b57',
+			'Knabbel E2E article fields',
+			static function (): void {
+				?>
+				<div class="acf-fields">
+					<div class="acf-field">
+						<div class="acf-label"><label>Test field</label></div>
+						<div class="acf-input"><input type="checkbox" disabled /></div>
+					</div>
+				</div>
+				<?php
+			},
+			'post',
+			'normal',
+			'high'
+		);
+	}
+);
+
+add_action(
+	'wp_ajax_knabbel_e2e_control',
+	static function (): void {
+		check_ajax_referer( 'knabbel_metabox_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ), 403 );
+		}
+
+		$post_id   = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+		$operation = isset( $_POST['operation'] ) ? sanitize_key( wp_unslash( $_POST['operation'] ) ) : 'inspect';
+
+		if ( ! $post_id || 'post' !== get_post_type( $post_id ) ) {
+			wp_send_json_error( array( 'message' => 'A valid post ID is required.' ), 400 );
+		}
+
+		$query = array(
+			'hook'     => 'knabbel_process_story',
+			'group'    => 'zw-knabbel-wp',
+			'status'   => ActionScheduler_Store::STATUS_PENDING,
+			'args'     => array( 'post_id' => $post_id ),
+			'per_page' => -1,
+		);
+
+		if ( 'run' === $operation ) {
+			$due_query                 = $query;
+			$due_query['date']         = time();
+			$due_query['date_compare'] = '<=';
+			$action_ids                = as_get_scheduled_actions( $due_query, 'ids' );
+
+			foreach ( $action_ids as $action_id ) {
+				ActionScheduler::runner()->process_action( $action_id, 'Knabbel browser E2E' );
+			}
+		} elseif ( 'inspect' !== $operation ) {
+			wp_send_json_error( array( 'message' => 'Unsupported operation.' ), 400 );
+		}
+
+		$pending = as_get_scheduled_actions( $query, 'ids' );
+		$state   = function_exists( 'KnabbelWP\\get_story_state' ) ? KnabbelWP\get_story_state( $post_id ) : array();
+
+		wp_send_json_success(
+			array(
+				'pending' => count( $pending ),
+				'state'   => $state,
+			)
+		);
+	}
+);

--- a/tests/e2e/mu-plugins/knabbel-e2e-control.php
+++ b/tests/e2e/mu-plugins/knabbel-e2e-control.php
@@ -23,17 +23,14 @@ add_action(
 	'add_meta_boxes_post',
 	static function (): void {
 		add_meta_box(
+			// This exact ID is load-bearing: assets/admin.js and assets/admin.css
+			// target #acf-group_5f21a05a18b57 (the production ACF group) to inject
+			// the radionieuws checkbox, and the original metabox is hidden
+			// unconditionally. Without a box of this ID the checkbox is unusable.
 			'acf-group_5f21a05a18b57',
 			'Knabbel E2E article fields',
 			static function (): void {
-				?>
-				<div class="acf-fields">
-					<div class="acf-field">
-						<div class="acf-label"><label>Test field</label></div>
-						<div class="acf-input"><input type="checkbox" disabled /></div>
-					</div>
-				</div>
-				<?php
+				echo '<div class="acf-fields"><div class="acf-field"></div></div>';
 			},
 			'post',
 			'normal',
@@ -41,6 +38,39 @@ add_action(
 		);
 	}
 );
+
+/**
+ * Run due Action Scheduler actions for a hook and fail loudly on errors.
+ *
+ * Shared by the AJAX control endpoint below and tests/e2e/suite.php.
+ *
+ * @param string                    $hook Action hook to run.
+ * @param array<string, mixed>|null $args Optional exact action arguments.
+ * @throws RuntimeException When an action does not complete successfully.
+ */
+function knabbel_e2e_run_due_actions( string $hook, ?array $args = null ): void {
+	$query = array(
+		'hook'         => $hook,
+		'group'        => 'zw-knabbel-wp',
+		'status'       => ActionScheduler_Store::STATUS_PENDING,
+		'date'         => time(),
+		'date_compare' => '<=',
+		'per_page'     => -1,
+	);
+
+	if ( null !== $args ) {
+		$query['args'] = $args;
+	}
+
+	foreach ( as_get_scheduled_actions( $query, 'ids' ) as $action_id ) {
+		ActionScheduler::runner()->process_action( $action_id, 'Knabbel E2E' );
+		$status = ActionScheduler::store()->get_status( $action_id );
+
+		if ( ActionScheduler_Store::STATUS_COMPLETE !== $status ) {
+			throw new RuntimeException( sprintf( 'Action Scheduler action %d finished with status %s.', (int) $action_id, esc_html( $status ) ) );
+		}
+	}
+}
 
 add_action(
 	'wp_ajax_knabbel_e2e_control',
@@ -58,34 +88,31 @@ add_action(
 			wp_send_json_error( array( 'message' => 'A valid post ID is required.' ), 400 );
 		}
 
-		$query = array(
-			'hook'     => 'knabbel_process_story',
-			'group'    => 'zw-knabbel-wp',
-			'status'   => ActionScheduler_Store::STATUS_PENDING,
-			'args'     => array( 'post_id' => $post_id ),
-			'per_page' => -1,
-		);
-
 		if ( 'run' === $operation ) {
-			$due_query                 = $query;
-			$due_query['date']         = time();
-			$due_query['date_compare'] = '<=';
-			$action_ids                = as_get_scheduled_actions( $due_query, 'ids' );
-
-			foreach ( $action_ids as $action_id ) {
-				ActionScheduler::runner()->process_action( $action_id, 'Knabbel browser E2E' );
+			try {
+				knabbel_e2e_run_due_actions( 'knabbel_process_story', array( 'post_id' => $post_id ) );
+			} catch ( RuntimeException $e ) {
+				wp_send_json_error( array( 'message' => $e->getMessage() ), 500 );
 			}
 		} elseif ( 'inspect' !== $operation ) {
 			wp_send_json_error( array( 'message' => 'Unsupported operation.' ), 400 );
 		}
 
-		$pending = as_get_scheduled_actions( $query, 'ids' );
-		$state   = function_exists( 'KnabbelWP\\get_story_state' ) ? KnabbelWP\get_story_state( $post_id ) : array();
+		$pending = as_get_scheduled_actions(
+			array(
+				'hook'     => 'knabbel_process_story',
+				'group'    => 'zw-knabbel-wp',
+				'status'   => ActionScheduler_Store::STATUS_PENDING,
+				'args'     => array( 'post_id' => $post_id ),
+				'per_page' => -1,
+			),
+			'ids'
+		);
 
 		wp_send_json_success(
 			array(
 				'pending' => count( $pending ),
-				'state'   => $state,
+				'state'   => KnabbelWP\get_story_state( $post_id ),
 			)
 		);
 	}

--- a/tests/e2e/mu-plugins/knabbel-e2e-control.php
+++ b/tests/e2e/mu-plugins/knabbel-e2e-control.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: Knabbel E2E Browser Control
- * Description: Deterministic editor and Action Scheduler controls for browser E2E tests.
+ * Plugin Name: Knabbel E2E Control
+ * Description: Deterministic editor and Action Scheduler controls for PHP and browser E2E tests.
  *
  * @package KnabbelWP
  */
@@ -12,6 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( 'wp_get_environment_type' ) || 'local' !== wp_get_environment_type() ) {
+	return;
+}
+
+// The browser suite exercises the plugin's classic metabox integration.
 add_filter(
 	'use_block_editor_for_post_type',
 	static fn( bool $use_block_editor, string $post_type ): bool => 'post' === $post_type ? false : $use_block_editor,
@@ -44,14 +49,16 @@ add_action(
  *
  * Shared by the AJAX control endpoint below and tests/e2e/suite.php.
  *
- * @param string                    $hook Action hook to run.
- * @param array<string, mixed>|null $args Optional exact action arguments.
+ * @param string                    $hook  Action hook to run.
+ * @param string                    $group Action Scheduler group to query.
+ * @param array<string, mixed>|null $args  Optional exact action arguments.
+ * @return int Number of actions processed.
  * @throws RuntimeException When an action does not complete successfully.
  */
-function knabbel_e2e_run_due_actions( string $hook, ?array $args = null ): void {
+function knabbel_e2e_run_due_actions( string $hook, string $group, ?array $args = null ): int {
 	$query = array(
 		'hook'         => $hook,
-		'group'        => 'zw-knabbel-wp',
+		'group'        => $group,
 		'status'       => ActionScheduler_Store::STATUS_PENDING,
 		'date'         => time(),
 		'date_compare' => '<=',
@@ -62,14 +69,26 @@ function knabbel_e2e_run_due_actions( string $hook, ?array $args = null ): void 
 		$query['args'] = $args;
 	}
 
+	$processed = 0;
 	foreach ( as_get_scheduled_actions( $query, 'ids' ) as $action_id ) {
 		ActionScheduler::runner()->process_action( $action_id, 'Knabbel E2E' );
 		$status = ActionScheduler::store()->get_status( $action_id );
 
 		if ( ActionScheduler_Store::STATUS_COMPLETE !== $status ) {
-			throw new RuntimeException( sprintf( 'Action Scheduler action %d finished with status %s.', (int) $action_id, esc_html( $status ) ) );
+			$messages = array_map(
+				static fn( ActionScheduler_LogEntry $entry ): string => $entry->get_message(),
+				ActionScheduler::logger()->get_logs( $action_id )
+			);
+			$logs     = array() === $messages ? 'none' : implode( ' | ', $messages );
+			throw new RuntimeException(
+				sprintf( 'Action Scheduler action %d finished with status %s. Logs: %s', (int) $action_id, $status, $logs )
+			);
 		}
+
+		++$processed;
 	}
+
+	return $processed;
 }
 
 add_action(
@@ -88,10 +107,11 @@ add_action(
 			wp_send_json_error( array( 'message' => 'A valid post ID is required.' ), 400 );
 		}
 
+		$processed = 0;
 		if ( 'run' === $operation ) {
 			try {
-				knabbel_e2e_run_due_actions( 'knabbel_process_story', array( 'post_id' => $post_id ) );
-			} catch ( RuntimeException $e ) {
+				$processed = knabbel_e2e_run_due_actions( 'knabbel_process_story', 'zw-knabbel-wp', array( 'post_id' => $post_id ) );
+			} catch ( Throwable $e ) {
 				wp_send_json_error( array( 'message' => $e->getMessage() ), 500 );
 			}
 		} elseif ( 'inspect' !== $operation ) {
@@ -111,8 +131,9 @@ add_action(
 
 		wp_send_json_success(
 			array(
-				'pending' => count( $pending ),
-				'state'   => KnabbelWP\get_story_state( $post_id ),
+				'pending'   => count( $pending ),
+				'processed' => $processed,
+				'state'     => (object) KnabbelWP\get_story_state( $post_id ),
 			)
 		);
 	}

--- a/tests/e2e/mu-plugins/knabbel-openai-stub.php
+++ b/tests/e2e/mu-plugins/knabbel-openai-stub.php
@@ -12,6 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( 'wp_get_environment_type' ) || 'local' !== wp_get_environment_type() ) {
+	return;
+}
+
 add_filter(
 	'pre_http_request',
 	static function ( false|array|WP_Error $preempt, array $parsed_args, string $url ): false|array|WP_Error {
@@ -33,6 +37,7 @@ add_filter(
 					'choices' => array(
 						array(
 							'message' => array(
+								// Keep in sync with suite.php and editor-flow.spec.ts.
 								'content' => 'Deterministische E2E-radiospreektekst.',
 							),
 						),

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -22,6 +22,11 @@ if [[ ! -f "$repo_root/vendor/autoload.php" ]]; then
 	exit 2
 fi
 
+if [[ ! -f "$repo_root/node_modules/@playwright/test/package.json" ]]; then
+	echo "Playwright dependencies are missing. Run npm install first." >&2
+	exit 2
+fi
+
 command -v docker >/dev/null 2>&1 || {
 	echo "Docker is required for the E2E suite." >&2
 	exit 2
@@ -58,9 +63,14 @@ rm -rf "$artifact_dir"
 echo "Starting isolated WordPress and Babbel services..."
 "${compose[@]}" up --detach --build --wait --wait-timeout 240 babbel wordpress
 
+wordpress_address=$("${compose[@]}" port wordpress 80)
+babbel_address=$("${compose[@]}" port babbel 8080)
+wordpress_url="http://$wordpress_address"
+babbel_url="http://$babbel_address/api/v1"
+
 echo "Installing WordPress..."
 wp core install \
-	--url=http://wordpress \
+	--url="$wordpress_url" \
 	--title='Knabbel E2E' \
 	--admin_user=admin \
 	--admin_password=e2e-admin-password \
@@ -68,6 +78,11 @@ wp core install \
 	--skip-email
 wp option update timezone_string Europe/Amsterdam
 wp plugin activate zw-knabbel-wp
+
+echo "Running browser E2E scenarios..."
+PLAYWRIGHT_BASE_URL="$wordpress_url" \
+	PLAYWRIGHT_BABBEL_URL="$babbel_url" \
+	npm run test:e2e:browser
 
 echo "Running E2E regression suite..."
 wp eval 'require "/var/www/html/wp-content/plugins/zw-knabbel-wp/tests/e2e/suite.php";'

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -63,7 +63,9 @@ truncate_wordpress_debug_log() {
 }
 
 assert_wordpress_debug_log_clean() {
-	collect_wordpress_debug_log
+	if ! collect_wordpress_debug_log; then
+		return 1
+	fi
 	# WP_DEBUG can capture ambient core errors. Fail only when the origin points into this plugin.
 	if grep -Ei 'PHP (warning|notice|deprecated|fatal error|parse error|recoverable fatal error).*/wp-content/plugins/zw-knabbel-wp/' \
 		"$wordpress_debug_log" >"$wordpress_php_errors"; then

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -34,23 +34,67 @@ command -v docker >/dev/null 2>&1 || {
 
 project_name=${COMPOSE_PROJECT_NAME:-zw-knabbel-e2e-$$}
 artifact_dir="$script_dir/artifacts"
+wordpress_debug_log="$artifact_dir/wordpress-debug.log"
+wordpress_php_errors="$artifact_dir/wordpress-php-errors.log"
 export BABBEL_PATH="$babbel_path"
 
 compose=(docker compose --project-name "$project_name" --file "$script_dir/compose.yml")
 
+collect_wordpress_debug_log() {
+	if ! mkdir -p "$artifact_dir"; then
+		echo "Could not create E2E artifact directory: $artifact_dir" >&2
+		return 1
+	fi
+
+	if ! "${compose[@]}" exec -T wordpress sh -c \
+		'if [ -f /var/www/html/wp-content/debug.log ]; then cat /var/www/html/wp-content/debug.log; fi' \
+		>"$wordpress_debug_log"; then
+		echo "Could not collect the WordPress debug log." >&2
+		return 1
+	fi
+}
+
+assert_wordpress_debug_log_clean() {
+	collect_wordpress_debug_log
+	if grep -Ei 'PHP (warning|notice|deprecated|fatal error|parse error|recoverable fatal error)' \
+		"$wordpress_debug_log" >"$wordpress_php_errors"; then
+		echo "WordPress emitted PHP errors:" >&2
+		cat "$wordpress_php_errors" >&2
+		return 1
+	else
+		grep_exit_code=$?
+		if ((grep_exit_code > 1)); then
+			echo "Could not inspect the WordPress debug log." >&2
+			return 1
+		fi
+	fi
+}
+
 cleanup() {
-	status=$?
+	cleanup_exit_code=$?
 	trap - EXIT
 
-	if ((status != 0)); then
-		mkdir -p "$artifact_dir"
-		"${compose[@]}" ps --all || true
-		"${compose[@]}" logs --no-color >"$artifact_dir/docker.log" 2>&1 || true
-		tail -n 300 "$artifact_dir/docker.log" || true
+	if ((cleanup_exit_code != 0)); then
+		if mkdir -p "$artifact_dir"; then
+			if ! "${compose[@]}" ps --all; then
+				echo "Could not collect Docker service status." >&2
+			fi
+			if ! "${compose[@]}" logs --no-color >"$artifact_dir/docker.log" 2>&1; then
+				echo "Could not collect Docker logs." >&2
+			fi
+			if [[ -f "$artifact_dir/docker.log" ]] && ! tail -n 300 "$artifact_dir/docker.log"; then
+				echo "Could not print the Docker log tail." >&2
+			fi
+			if ! collect_wordpress_debug_log; then
+				echo "WordPress debug log collection failed during cleanup." >&2
+			fi
+		else
+			echo "Could not create E2E artifact directory during cleanup." >&2
+		fi
 	fi
 
 	"${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
-	exit "$status"
+	exit "$cleanup_exit_code"
 }
 trap cleanup EXIT
 
@@ -65,24 +109,35 @@ echo "Starting isolated WordPress and Babbel services..."
 
 wordpress_address=$("${compose[@]}" port wordpress 80)
 babbel_address=$("${compose[@]}" port babbel 8080)
+if [[ -z "$wordpress_address" || -z "$babbel_address" ]]; then
+	echo "Docker Compose did not return the required published service ports." >&2
+	exit 1
+fi
 wordpress_url="http://$wordpress_address"
 babbel_url="http://$babbel_address/api/v1"
 
 echo "Installing WordPress..."
+# Keep the admin fixture credentials in sync with tests/playwright/utils.ts.
 wp core install \
 	--url="$wordpress_url" \
 	--title='Knabbel E2E' \
 	--admin_user=admin \
 	--admin_password=e2e-admin-password \
 	--admin_email=e2e@example.test \
+	--locale=en_US \
 	--skip-email
 wp option update timezone_string Europe/Amsterdam
 wp plugin activate zw-knabbel-wp
+# The dollar-prefixed variables are evaluated by PHP inside the container.
+# shellcheck disable=SC2016
+wp eval '$settings = get_option( "knabbel_settings", array() ); if ( 1 !== ( $settings["start_days_offset"] ?? null ) || "draft" !== ( $settings["default_status"] ?? null ) ) { throw new RuntimeException( "Plugin activation defaults are incorrect." ); }'
 
 echo "Running browser E2E scenarios..."
 PLAYWRIGHT_BASE_URL="$wordpress_url" \
 	PLAYWRIGHT_BABBEL_URL="$babbel_url" \
-	npm run test:e2e:browser
+	npm --prefix "$repo_root" run test:e2e:browser
+assert_wordpress_debug_log_clean
 
 echo "Running E2E regression suite..."
 wp eval 'require "/var/www/html/wp-content/plugins/zw-knabbel-wp/tests/e2e/suite.php";'
+assert_wordpress_debug_log_clean

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -54,11 +54,20 @@ collect_wordpress_debug_log() {
 	fi
 }
 
+truncate_wordpress_debug_log() {
+	if ! "${compose[@]}" exec -T wordpress sh -c \
+		'if [ -f /var/www/html/wp-content/debug.log ]; then : > /var/www/html/wp-content/debug.log; fi'; then
+		echo "Could not truncate the WordPress debug log." >&2
+		return 1
+	fi
+}
+
 assert_wordpress_debug_log_clean() {
 	collect_wordpress_debug_log
-	if grep -Ei 'PHP (warning|notice|deprecated|fatal error|parse error|recoverable fatal error)' \
+	# WP_DEBUG can capture ambient core errors. Fail only when the origin points into this plugin.
+	if grep -Ei 'PHP (warning|notice|deprecated|fatal error|parse error|recoverable fatal error).*/wp-content/plugins/zw-knabbel-wp/' \
 		"$wordpress_debug_log" >"$wordpress_php_errors"; then
-		echo "WordPress emitted PHP errors:" >&2
+		echo "The zw-knabbel-wp plugin emitted PHP errors:" >&2
 		cat "$wordpress_php_errors" >&2
 		return 1
 	else
@@ -68,6 +77,7 @@ assert_wordpress_debug_log_clean() {
 			return 1
 		fi
 	fi
+	truncate_wordpress_debug_log
 }
 
 cleanup() {

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -43,16 +43,26 @@ compose=(docker compose --project-name "$project_name" --file "$script_dir/compo
 # Drain the container log into the artifact, so each phase only reports its own
 # errors and a later collection can never clobber an earlier diagnostic.
 collect_wordpress_debug_log() {
-	mkdir -p "$artifact_dir"
+	if ! mkdir -p "$artifact_dir"; then
+		echo "Could not create the E2E artifact directory." >&2
+		return 1
+	fi
+
 	# The dollar-prefixed variables are evaluated by sh inside the container.
 	# shellcheck disable=SC2016
-	"${compose[@]}" exec -T wordpress sh -c \
+	if ! "${compose[@]}" exec -T wordpress sh -eu -c \
 		'log=/var/www/html/wp-content/debug.log; if [ -f "$log" ]; then cat "$log"; : >"$log"; fi' \
-		>>"$wordpress_debug_log"
+		>>"$wordpress_debug_log"; then
+		echo "Could not collect the WordPress debug log." >&2
+		return 1
+	fi
 }
 
 assert_wordpress_debug_log_clean() {
-	collect_wordpress_debug_log
+	if ! collect_wordpress_debug_log; then
+		return 1
+	fi
+
 	# WP_DEBUG can capture ambient core errors. Fail only when the origin points into this plugin.
 	local grep_status=0
 	grep -Ei 'PHP (warning|notice|deprecated|fatal error|parse error|recoverable fatal error).*/wp-content/plugins/zw-knabbel-wp/' \

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -40,73 +40,52 @@ export BABBEL_PATH="$babbel_path"
 
 compose=(docker compose --project-name "$project_name" --file "$script_dir/compose.yml")
 
+# Drain the container log into the artifact, so each phase only reports its own
+# errors and a later collection can never clobber an earlier diagnostic.
 collect_wordpress_debug_log() {
-	if ! mkdir -p "$artifact_dir"; then
-		echo "Could not create E2E artifact directory: $artifact_dir" >&2
-		return 1
-	fi
-
-	if ! "${compose[@]}" exec -T wordpress sh -c \
-		'if [ -f /var/www/html/wp-content/debug.log ]; then cat /var/www/html/wp-content/debug.log; fi' \
-		>"$wordpress_debug_log"; then
-		echo "Could not collect the WordPress debug log." >&2
-		return 1
-	fi
-}
-
-truncate_wordpress_debug_log() {
-	if ! "${compose[@]}" exec -T wordpress sh -c \
-		'if [ -f /var/www/html/wp-content/debug.log ]; then : > /var/www/html/wp-content/debug.log; fi'; then
-		echo "Could not truncate the WordPress debug log." >&2
-		return 1
-	fi
+	mkdir -p "$artifact_dir"
+	# The dollar-prefixed variables are evaluated by sh inside the container.
+	# shellcheck disable=SC2016
+	"${compose[@]}" exec -T wordpress sh -c \
+		'log=/var/www/html/wp-content/debug.log; if [ -f "$log" ]; then cat "$log"; : >"$log"; fi' \
+		>>"$wordpress_debug_log"
 }
 
 assert_wordpress_debug_log_clean() {
-	if ! collect_wordpress_debug_log; then
-		return 1
-	fi
+	collect_wordpress_debug_log
 	# WP_DEBUG can capture ambient core errors. Fail only when the origin points into this plugin.
-	if grep -Ei 'PHP (warning|notice|deprecated|fatal error|parse error|recoverable fatal error).*/wp-content/plugins/zw-knabbel-wp/' \
-		"$wordpress_debug_log" >"$wordpress_php_errors"; then
+	local grep_status=0
+	grep -Ei 'PHP (warning|notice|deprecated|fatal error|parse error|recoverable fatal error).*/wp-content/plugins/zw-knabbel-wp/' \
+		"$wordpress_debug_log" >"$wordpress_php_errors" || grep_status=$?
+
+	if ((grep_status == 0)); then
 		echo "The zw-knabbel-wp plugin emitted PHP errors:" >&2
 		cat "$wordpress_php_errors" >&2
 		return 1
-	else
-		grep_exit_code=$?
-		if ((grep_exit_code > 1)); then
-			echo "Could not inspect the WordPress debug log." >&2
-			return 1
-		fi
 	fi
-	truncate_wordpress_debug_log
+
+	# grep exits 1 when there is simply nothing to report; anything above that is a
+	# real failure and must never read as a clean log.
+	if ((grep_status > 1)); then
+		echo "Could not inspect the WordPress debug log." >&2
+		return 1
+	fi
 }
 
 cleanup() {
-	cleanup_exit_code=$?
+	status=$?
 	trap - EXIT
 
-	if ((cleanup_exit_code != 0)); then
-		if mkdir -p "$artifact_dir"; then
-			if ! "${compose[@]}" ps --all; then
-				echo "Could not collect Docker service status." >&2
-			fi
-			if ! "${compose[@]}" logs --no-color >"$artifact_dir/docker.log" 2>&1; then
-				echo "Could not collect Docker logs." >&2
-			fi
-			if [[ -f "$artifact_dir/docker.log" ]] && ! tail -n 300 "$artifact_dir/docker.log"; then
-				echo "Could not print the Docker log tail." >&2
-			fi
-			if ! collect_wordpress_debug_log; then
-				echo "WordPress debug log collection failed during cleanup." >&2
-			fi
-		else
-			echo "Could not create E2E artifact directory during cleanup." >&2
-		fi
+	if ((status != 0)); then
+		mkdir -p "$artifact_dir" || true
+		"${compose[@]}" ps --all || true
+		"${compose[@]}" logs --no-color >"$artifact_dir/docker.log" 2>&1 || true
+		tail -n 300 "$artifact_dir/docker.log" || true
+		collect_wordpress_debug_log || true
 	fi
 
 	"${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
-	exit "$cleanup_exit_code"
+	exit "$status"
 }
 trap cleanup EXIT
 

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -559,30 +559,13 @@ final class Knabbel_E2E_Suite {
 	/**
 	 * Run due actions through Action Scheduler's queue runner.
 	 *
+	 * Delegates to the shared helper in the knabbel-e2e-control MU plugin.
+	 *
 	 * @param string $hook Hook to execute.
 	 * @throws RuntimeException When an action does not complete successfully.
 	 */
 	private function run_action_scheduler( string $hook ): void {
-		$ids = as_get_scheduled_actions(
-			array(
-				'hook'         => $hook,
-				'group'        => self::ACTION_GROUP,
-				'status'       => ActionScheduler_Store::STATUS_PENDING,
-				'date'         => time(),
-				'date_compare' => '<=',
-				'per_page'     => -1,
-			),
-			'ids'
-		);
-
-		foreach ( $ids as $id ) {
-			ActionScheduler::runner()->process_action( $id, 'Knabbel E2E' );
-			$status = ActionScheduler::store()->get_status( $id );
-
-			if ( ActionScheduler_Store::STATUS_COMPLETE !== $status ) {
-				throw new RuntimeException( sprintf( 'Action Scheduler action %d finished with status %s.', $id, $status ) );
-			}
-		}
+		knabbel_e2e_run_due_actions( $hook );
 	}
 
 	/**

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -182,7 +182,7 @@ final class Knabbel_E2E_Suite {
 		$this->update_post( $post_id, array( 'post_title' => $title ) );
 		$this->assert_same( 1, $this->story_action_count( $post_id ), 'Repeated saves must not duplicate the pending action.' );
 
-		$this->run_action_scheduler( self::STORY_HOOK );
+		$this->run_action_scheduler( self::STORY_HOOK, 1, array( 'post_id' => $post_id ) );
 		$dates_after = KnabbelWP\calculate_story_dates( 'now' );
 		$state       = KnabbelWP\get_story_state( $post_id );
 		$this->assert_same( StoryStatus::Sent->value, $state['status'] ?? null, 'The worker must mark a created story sent.' );
@@ -287,7 +287,7 @@ final class Knabbel_E2E_Suite {
 		$this->assert_same( $first_date, get_post( $post_id )->post_date ?? null, 'Scheduled fixture must retain its local publication date.' );
 		$this->assert_same( 'future', get_post_status( $post_id ), 'Scheduled fixture must retain future status before processing.' );
 		$this->assert_same( 1, $this->story_action_count( $post_id ), 'Scheduling must enqueue one worker action.' );
-		$this->run_action_scheduler( self::STORY_HOOK );
+		$this->run_action_scheduler( self::STORY_HOOK, 1, array( 'post_id' => $post_id ) );
 
 		$state    = KnabbelWP\get_story_state( $post_id );
 		$story_id = (string) ( $state['story_id'] ?? '' );
@@ -336,7 +336,7 @@ final class Knabbel_E2E_Suite {
 		$this->update_post( $post_id, array( 'post_status' => 'draft' ) );
 		$this->assert_same( 0, $this->story_action_count( $post_id ), 'Returning to draft must cancel pending work.' );
 		$this->assert_same( array(), KnabbelWP\get_story_state( $post_id ), 'Cancellation before processing must clear local story state.' );
-		$this->run_action_scheduler( self::STORY_HOOK, 0 );
+		$this->run_action_scheduler( self::STORY_HOOK, 0, array( 'post_id' => $post_id ) );
 		$this->assert_same( 0, $this->count_babbel_stories_by_title( $title ), 'Canceled work must never create a Babbel story.' );
 	}
 
@@ -532,7 +532,7 @@ final class Knabbel_E2E_Suite {
 	 */
 	private function publish_and_process( int $post_id ): void {
 		$this->update_post( $post_id, array( 'post_status' => 'publish' ) );
-		$this->run_action_scheduler( self::STORY_HOOK );
+		$this->run_action_scheduler( self::STORY_HOOK, 1, array( 'post_id' => $post_id ) );
 	}
 
 	/**
@@ -558,16 +558,17 @@ final class Knabbel_E2E_Suite {
 	 *
 	 * Delegates to the shared helper in the knabbel-e2e-control MU plugin.
 	 *
-	 * @param string $hook           Hook to execute.
-	 * @param int    $expected_count Expected number of actions to process.
+	 * @param string                    $hook           Hook to execute.
+	 * @param int                       $expected_count Expected number of actions to process.
+	 * @param array<string, mixed>|null $args           Optional exact action arguments.
 	 * @throws RuntimeException When an action does not complete successfully.
 	 */
-	private function run_action_scheduler( string $hook, int $expected_count = 1 ): void {
+	private function run_action_scheduler( string $hook, int $expected_count = 1, ?array $args = null ): void {
 		if ( ! function_exists( 'knabbel_e2e_run_due_actions' ) ) {
 			throw new RuntimeException( 'The Knabbel E2E control MU plugin is required. Check the tests/e2e/compose.yml mount.' );
 		}
 
-		$processed = knabbel_e2e_run_due_actions( $hook, self::ACTION_GROUP );
+		$processed = knabbel_e2e_run_due_actions( $hook, self::ACTION_GROUP, $args );
 		$this->assert_same( $expected_count, $processed, sprintf( 'Expected %d due action(s) for hook %s.', $expected_count, $hook ) );
 	}
 

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -702,22 +702,16 @@ final class Knabbel_E2E_Suite {
 	 * @return int Matching count.
 	 */
 	private function count_babbel_stories_by_title( string $title ): int {
-		$path     = '/stories?' . http_build_query(
+		$path    = '/stories?' . http_build_query(
 			array(
 				'filter' => array( 'title' => $title ),
 				'limit'  => 100,
 			)
 		);
-		$response = $this->babbel_request( 'GET', $path );
-		$this->assert_same( 200, wp_remote_retrieve_response_code( $response ), 'Babbel story list must be readable.' );
-		$raw_body = wp_remote_retrieve_body( $response );
-		$decoded  = json_decode( $raw_body, true, 512, JSON_THROW_ON_ERROR );
-		$this->assert_true( is_array( $decoded ), 'Babbel story list must decode to an object. Body: ' . $raw_body );
-		$this->assert_true( is_array( $decoded['data'] ?? null ), 'Babbel story list data must be an array. Body: ' . $raw_body );
-		$stories = $decoded['data'];
-		$this->assert_same( 100, $decoded['limit'] ?? null, 'Babbel story list must honor the requested limit.' );
-		$this->assert_same( 0, $decoded['offset'] ?? null, 'Babbel story list must start at offset zero.' );
-		$this->assert_same( count( $stories ), $decoded['total'] ?? null, 'Babbel story list must fit on one page.' );
+		$decoded = $this->babbel_get_json( $path, 'Babbel story list must be readable.' );
+		$stories = $decoded['data'] ?? null;
+		$this->assert_true( is_array( $stories ), 'Babbel story list data must be an array.' );
+		// The filter is applied server-side, so a full page means results were truncated.
 		$this->assert_true( count( $stories ) < 100, 'Babbel story list must not fill the verification page.' );
 
 		return count(

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -25,7 +25,8 @@ final class Knabbel_E2E_Suite {
 	private const STORY_HOOK      = 'knabbel_process_story';
 	private const FEW_SHOT_HOOK   = 'knabbel_sync_few_shot_examples';
 	private const ACTION_GROUP    = 'zw-knabbel-wp';
-	private const GENERATED_TEXT  = 'Deterministische E2E-radiospreektekst.';
+	// Keep in sync with the OpenAI MU plugin and editor-flow.spec.ts.
+	private const GENERATED_TEXT = 'Deterministische E2E-radiospreektekst.';
 
 	/**
 	 * Cookies for the independent Babbel verification client.
@@ -59,7 +60,7 @@ final class Knabbel_E2E_Suite {
 	 * Execute all scenarios in dependency order.
 	 */
 	public function run(): void {
-		$this->run_case( 'E2E-001', 'plugin activation, recurring queue and Babbel authentication', $this->test_bootstrap_and_authentication( ... ) );
+		$this->run_case( 'E2E-001', 'plugin bootstrap, recurring queue and Babbel authentication', $this->test_bootstrap_and_authentication( ... ) );
 		$this->run_case( 'E2E-002', 'published post creates exactly one complete Babbel story', $this->test_published_story_creation( ... ) );
 		$this->run_case( 'E2E-003', 'edits synchronize and recover from an authentication failure', $this->test_update_and_error_recovery( ... ) );
 		$this->run_case( 'E2E-004', 'checkbox disable soft-deletes and re-enable restores', $this->test_checkbox_delete_and_restore( ... ) );
@@ -128,14 +129,10 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify activation defaults, a single recurring action, login and 401 retry.
+	 * Verify plugin bootstrap, a single recurring action, login and 401 retry.
 	 */
 	private function test_bootstrap_and_authentication(): void {
 		$this->assert_true( defined( 'KNABBEL_VERSION' ), 'The plugin bootstrap must be loaded.' );
-
-		$settings = get_option( 'knabbel_settings', array() );
-		$this->assert_same( 1, $settings['start_days_offset'] ?? null, 'Activation must set the default start offset.' );
-		$this->assert_same( 'draft', $settings['default_status'] ?? null, 'Activation must set the default story status.' );
 
 		KnabbelWP\few_shot_schedule_sync();
 		$this->assert_same(
@@ -339,7 +336,7 @@ final class Knabbel_E2E_Suite {
 		$this->update_post( $post_id, array( 'post_status' => 'draft' ) );
 		$this->assert_same( 0, $this->story_action_count( $post_id ), 'Returning to draft must cancel pending work.' );
 		$this->assert_same( array(), KnabbelWP\get_story_state( $post_id ), 'Cancellation before processing must clear local story state.' );
-		$this->run_action_scheduler( self::STORY_HOOK );
+		$this->run_action_scheduler( self::STORY_HOOK, 0 );
 		$this->assert_same( 0, $this->count_babbel_stories_by_title( $title ), 'Canceled work must never create a Babbel story.' );
 	}
 
@@ -561,11 +558,17 @@ final class Knabbel_E2E_Suite {
 	 *
 	 * Delegates to the shared helper in the knabbel-e2e-control MU plugin.
 	 *
-	 * @param string $hook Hook to execute.
+	 * @param string $hook           Hook to execute.
+	 * @param int    $expected_count Expected number of actions to process.
 	 * @throws RuntimeException When an action does not complete successfully.
 	 */
-	private function run_action_scheduler( string $hook ): void {
-		knabbel_e2e_run_due_actions( $hook );
+	private function run_action_scheduler( string $hook, int $expected_count = 1 ): void {
+		if ( ! function_exists( 'knabbel_e2e_run_due_actions' ) ) {
+			throw new RuntimeException( 'The Knabbel E2E control MU plugin is required. Check the tests/e2e/compose.yml mount.' );
+		}
+
+		$processed = knabbel_e2e_run_due_actions( $hook, self::ACTION_GROUP );
+		$this->assert_same( $expected_count, $processed, sprintf( 'Expected %d due action(s) for hook %s.', $expected_count, $hook ) );
 	}
 
 	/**
@@ -640,6 +643,7 @@ final class Knabbel_E2E_Suite {
 	 * @throws RuntimeException When the HTTP request fails.
 	 */
 	private function babbel_login(): void {
+		// Keep the Babbel fixture credentials in sync with tests/playwright/utils.ts.
 		$response = wp_remote_post(
 			self::BABBEL_BASE_URL . '/sessions',
 			array(
@@ -698,14 +702,23 @@ final class Knabbel_E2E_Suite {
 	 * @return int Matching count.
 	 */
 	private function count_babbel_stories_by_title( string $title ): int {
-		$path    = '/stories?' . http_build_query(
+		$path     = '/stories?' . http_build_query(
 			array(
 				'filter' => array( 'title' => $title ),
 				'limit'  => 100,
 			)
 		);
-		$decoded = $this->babbel_get_json( $path, 'Babbel story list must be readable.' );
-		$stories = is_array( $decoded['data'] ?? null ) ? $decoded['data'] : array();
+		$response = $this->babbel_request( 'GET', $path );
+		$this->assert_same( 200, wp_remote_retrieve_response_code( $response ), 'Babbel story list must be readable.' );
+		$raw_body = wp_remote_retrieve_body( $response );
+		$decoded  = json_decode( $raw_body, true, 512, JSON_THROW_ON_ERROR );
+		$this->assert_true( is_array( $decoded ), 'Babbel story list must decode to an object. Body: ' . $raw_body );
+		$this->assert_true( is_array( $decoded['data'] ?? null ), 'Babbel story list data must be an array. Body: ' . $raw_body );
+		$stories = $decoded['data'];
+		$this->assert_same( 100, $decoded['limit'] ?? null, 'Babbel story list must honor the requested limit.' );
+		$this->assert_same( 0, $decoded['offset'] ?? null, 'Babbel story list must start at offset zero.' );
+		$this->assert_same( count( $stories ), $decoded['total'] ?? null, 'Babbel story list must fit on one page.' );
+		$this->assert_true( count( $stories ) < 100, 'Babbel story list must not fill the verification page.' );
 
 		return count(
 			array_filter(

--- a/tests/playwright/auth.setup.ts
+++ b/tests/playwright/auth.setup.ts
@@ -1,0 +1,8 @@
+import { test as setup } from '@playwright/test';
+import { STORAGE_STATE } from '../../playwright.config';
+import { login } from './utils';
+
+setup('log in als beheerder', async ({ page }) => {
+	await login(page);
+	await page.context().storageState({ path: STORAGE_STATE });
+});

--- a/tests/playwright/auth.setup.ts
+++ b/tests/playwright/auth.setup.ts
@@ -1,8 +1,8 @@
-import { test as setup } from '@playwright/test';
 import { STORAGE_STATE } from '../../playwright.config';
+import { test as setup } from './fixtures';
 import { login } from './utils';
 
 setup('log in als beheerder', async ({ page }) => {
-	await login(page);
-	await page.context().storageState({ path: STORAGE_STATE });
+    await login(page);
+    await page.context().storageState({ path: STORAGE_STATE });
 });

--- a/tests/playwright/editor-flow.spec.ts
+++ b/tests/playwright/editor-flow.spec.ts
@@ -1,0 +1,232 @@
+import { expect, test } from '@playwright/test';
+import {
+	countBabbelStoriesByTitle,
+	currentPostID,
+	getBabbelStory,
+	inspectStory,
+	login,
+	loginToBabbel,
+	runStoryActions,
+	savePost,
+	setBabbelEnabled,
+} from './utils';
+
+const runID = Date.now().toString();
+const originalTitle = `Browser E2E bericht ${runID}`;
+const updatedTitle = `${originalTitle} bijgewerkt`;
+const originalContent =
+	'Dit artikel wordt volledig via de WordPress-editor gepubliceerd en naar Babbel gestuurd.';
+const updatedContent =
+	'De redacteur heeft de inhoud via de WordPress-editor aangepast.';
+
+test.describe.serial('WordPress redacteursflow', () => {
+	let postID = 0;
+	let storyID = '';
+	let generatedText = '';
+
+	test.beforeEach(async ({ page }) => {
+		await login(page);
+	});
+
+	test('beheerder configureert en test de integratie via Instellingen', async ({
+		page,
+	}) => {
+		await page.goto(
+			'/wp-admin/options-general.php?page=zw-knabbel-wp-settings',
+		);
+
+		await page
+			.locator('[name="knabbel_settings[api_base_url]"]')
+			.fill('http://babbel:8080/api/v1');
+		await page
+			.locator('[name="knabbel_settings[api_username]"]')
+			.fill('admin');
+		await page
+			.locator('[name="knabbel_settings[api_password]"]')
+			.fill('admin');
+		await page
+			.locator('[name="knabbel_settings[openai_api_key]"]')
+			.fill('e2e-openai-key');
+		await page
+			.locator('[name="knabbel_settings[openai_model]"]')
+			.fill('e2e-model');
+		await page
+			.locator('[name="knabbel_settings[few_shot_count]"]')
+			.fill('1');
+		await page
+			.locator('[name="knabbel_settings[start_days_offset]"]')
+			.fill('1');
+		await page
+			.locator('[name="knabbel_settings[end_days_offset]"]')
+			.fill('2');
+
+		const debugMode = page.locator(
+			'[name="knabbel_settings[debug_mode]"]',
+		);
+		if (!(await debugMode.isChecked())) {
+			await page.getByText('Enable Debug Mode', { exact: true }).click();
+		}
+
+		await Promise.all([
+			page.waitForNavigation(),
+			page.locator('button[form="knabbel-settings-form"]').click(),
+		]);
+		await expect(
+			page.locator('[name="knabbel_settings[api_base_url]"]'),
+		).toHaveValue('http://babbel:8080/api/v1');
+		await expect(debugMode).toBeChecked();
+
+		// The button's hover transform keeps Playwright's stability check moving.
+		await page.locator('#test-babbel-api').click({ force: true });
+		await expect(page.locator('#api-test-result')).toContainText(/admin/i);
+	});
+
+	test('redacteur publiceert een bericht en laat de wachtrij het naar Babbel sturen', async ({
+		page,
+	}) => {
+		await page.goto('/wp-admin/post-new.php');
+		await page.locator('#title').fill(originalTitle);
+		await page.locator('#content-html').click();
+		await page.locator('#content').fill(originalContent);
+		await setBabbelEnabled(page, true);
+
+		await savePost(page);
+		postID = currentPostID(page);
+		await expect(page.locator('.knabbel-status-badge.scheduled')).toBeVisible();
+
+		const result = await runStoryActions(page, postID);
+		expect(result.pending).toBe(0);
+		expect(result.state.status).toBe('sent');
+		expect(result.state.story_id).toBeTruthy();
+		storyID = result.state.story_id || '';
+		generatedText = result.state.generated_speech_text || '';
+
+		await page.reload();
+		await expect(page.locator('.knabbel-status-badge.sent')).toBeVisible();
+		await expect(page.locator('#knabbel_send_to_babbel')).toBeChecked();
+
+		await loginToBabbel();
+		const { response, story } = await getBabbelStory(storyID);
+		expect(response.status()).toBe(200);
+		expect(story?.title).toBe(originalTitle);
+		expect(story?.text).toBe('Deterministische E2E-radiospreektekst.');
+		expect(story?.metadata?.wordpress_id).toBe(postID);
+	});
+
+	test('redacteur bewerkt titel en inhoud zonder bestaande spreektekst te overschrijven', async ({
+		page,
+	}) => {
+		await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
+		await page.locator('#title').fill(updatedTitle);
+		await page.locator('#content-html').click();
+		await page.locator('#content').fill(updatedContent);
+		await savePost(page);
+
+		await loginToBabbel();
+		const { response, story } = await getBabbelStory(storyID);
+		expect(response.status()).toBe(200);
+		expect(story?.title).toBe(updatedTitle);
+		expect(story?.text).toBe(generatedText);
+		await expect(page.locator('#title')).toHaveValue(updatedTitle);
+		await expect(page.locator('#content')).toHaveValue(updatedContent);
+	});
+
+	test('redacteur schakelt Babbel uit en herstelt daarna hetzelfde verhaal', async ({
+		page,
+	}) => {
+		await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
+		await setBabbelEnabled(page, false);
+		await savePost(page);
+		await expect(page.locator('.knabbel-status-badge.deleted')).toBeVisible();
+
+		await loginToBabbel();
+		let remote = await getBabbelStory(storyID);
+		expect(remote.response.status()).toBe(404);
+
+		await page.reload();
+		await setBabbelEnabled(page, true);
+		await savePost(page);
+		await expect(page.locator('.knabbel-status-badge.sent')).toBeVisible();
+
+		remote = await getBabbelStory(storyID);
+		expect(remote.response.status()).toBe(200);
+		expect(remote.story?.id).toBe(storyID);
+	});
+
+	test('redacteur plant een bericht en annuleert het voor verwerking', async ({
+		page,
+	}) => {
+		const scheduledTitle = `Browser E2E planning ${runID}`;
+		const publication = new Date();
+		publication.setDate(publication.getDate() + 10);
+		publication.setHours(12, 0, 0, 0);
+
+		await page.goto('/wp-admin/post-new.php');
+		await page.locator('#title').fill(scheduledTitle);
+		await page.locator('#content-html').click();
+		await page.locator('#content').fill(originalContent);
+		await setBabbelEnabled(page, true);
+		await page.locator('.edit-timestamp').click();
+		await page
+			.locator('#mm')
+			.selectOption(String(publication.getMonth() + 1).padStart(2, '0'));
+		await page
+			.locator('#jj')
+			.fill(String(publication.getDate()).padStart(2, '0'));
+		await page.locator('#aa').fill(String(publication.getFullYear()));
+		await page.locator('#hh').fill('12');
+		await page.locator('#mn').fill('00');
+		await page.locator('.save-timestamp').click();
+		await expect(page.locator('#publish')).toHaveValue('Schedule');
+
+		await savePost(page);
+		const scheduledPostID = currentPostID(page);
+		let result = await inspectStory(page, scheduledPostID);
+		expect(result.pending).toBe(1);
+		expect(result.state.status).toBe('scheduled');
+
+		await page.locator('.edit-post-status').click({ force: true });
+		await expect(page.locator('#post_status')).toBeVisible();
+		await page.locator('#post_status').selectOption('draft');
+		await page.locator('.save-post-status').click({ force: true });
+		await savePost(page);
+
+		result = await inspectStory(page, scheduledPostID);
+		expect(result.pending).toBe(0);
+		expect(result.state).toEqual([]);
+
+		await loginToBabbel();
+		expect(await countBabbelStoriesByTitle(scheduledTitle)).toBe(0);
+	});
+
+	test('redacteur verplaatst het bericht naar de prullenbak en herstelt het', async ({
+		page,
+	}) => {
+		await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
+		await Promise.all([
+			page.waitForNavigation(),
+			page.locator('#delete-action .submitdelete').click(),
+		]);
+
+		await loginToBabbel();
+		let remote = await getBabbelStory(storyID);
+		expect(remote.response.status()).toBe(404);
+
+		await page.goto('/wp-admin/edit.php?post_status=trash&post_type=post');
+		const row = page.locator('tr', {
+			has: page.getByText(updatedTitle, { exact: true }),
+		});
+		await expect(row).toBeVisible();
+		const restoreURL = await row
+			.getByRole('link', { name: /^Restore .* from the Trash$/ })
+			.getAttribute('href');
+		expect(restoreURL).toBeTruthy();
+		await page.goto(restoreURL || '');
+		await expect(page).toHaveURL(/\/wp-admin\/edit\.php/);
+
+		remote = await getBabbelStory(storyID);
+		expect(remote.response.status()).toBe(200);
+		expect(remote.story?.id).toBe(storyID);
+		expect(remote.story?.title).toBe(updatedTitle);
+	});
+});

--- a/tests/playwright/editor-flow.spec.ts
+++ b/tests/playwright/editor-flow.spec.ts
@@ -1,12 +1,10 @@
 import { expect, test } from '@playwright/test';
 import {
+	BABBEL_ADMIN,
+	controlStory,
 	countBabbelStoriesByTitle,
 	currentPostID,
 	getBabbelStory,
-	inspectStory,
-	login,
-	loginToBabbel,
-	runStoryActions,
 	savePost,
 	setBabbelEnabled,
 } from './utils';
@@ -24,10 +22,6 @@ test.describe.serial('WordPress redacteursflow', () => {
 	let storyID = '';
 	let generatedText = '';
 
-	test.beforeEach(async ({ page }) => {
-		await login(page);
-	});
-
 	test('beheerder configureert en test de integratie via Instellingen', async ({
 		page,
 	}) => {
@@ -35,30 +29,19 @@ test.describe.serial('WordPress redacteursflow', () => {
 			'/wp-admin/options-general.php?page=zw-knabbel-wp-settings',
 		);
 
-		await page
-			.locator('[name="knabbel_settings[api_base_url]"]')
-			.fill('http://babbel:8080/api/v1');
-		await page
-			.locator('[name="knabbel_settings[api_username]"]')
-			.fill('admin');
-		await page
-			.locator('[name="knabbel_settings[api_password]"]')
-			.fill('admin');
-		await page
-			.locator('[name="knabbel_settings[openai_api_key]"]')
-			.fill('e2e-openai-key');
-		await page
-			.locator('[name="knabbel_settings[openai_model]"]')
-			.fill('e2e-model');
-		await page
-			.locator('[name="knabbel_settings[few_shot_count]"]')
-			.fill('1');
-		await page
-			.locator('[name="knabbel_settings[start_days_offset]"]')
-			.fill('1');
-		await page
-			.locator('[name="knabbel_settings[end_days_offset]"]')
-			.fill('2');
+		const settings = {
+			api_base_url: 'http://babbel:8080/api/v1',
+			api_username: BABBEL_ADMIN.username,
+			api_password: BABBEL_ADMIN.password,
+			openai_api_key: 'e2e-openai-key',
+			openai_model: 'e2e-model',
+			few_shot_count: '1',
+			start_days_offset: '1',
+			end_days_offset: '2',
+		};
+		for (const [key, value] of Object.entries(settings)) {
+			await page.locator(`[name="knabbel_settings[${key}]"]`).fill(value);
+		}
 
 		const debugMode = page.locator(
 			'[name="knabbel_settings[debug_mode]"]',
@@ -78,7 +61,7 @@ test.describe.serial('WordPress redacteursflow', () => {
 		).toHaveValue('http://babbel:8080/api/v1');
 		await expect(debugMode).toBeChecked();
 
-		// The button's hover transform keeps Playwright's stability check moving.
+		// The button's `transition: all` keeps Playwright's stability check waiting.
 		await page.locator('#test-babbel-api').click({ force: true });
 		await expect(page.locator('#api-test-result')).toContainText(/admin/i);
 	});
@@ -96,7 +79,7 @@ test.describe.serial('WordPress redacteursflow', () => {
 		postID = currentPostID(page);
 		await expect(page.locator('.knabbel-status-badge.scheduled')).toBeVisible();
 
-		const result = await runStoryActions(page, postID);
+		const result = await controlStory(page, postID, 'run');
 		expect(result.pending).toBe(0);
 		expect(result.state.status).toBe('sent');
 		expect(result.state.story_id).toBeTruthy();
@@ -107,7 +90,6 @@ test.describe.serial('WordPress redacteursflow', () => {
 		await expect(page.locator('.knabbel-status-badge.sent')).toBeVisible();
 		await expect(page.locator('#knabbel_send_to_babbel')).toBeChecked();
 
-		await loginToBabbel();
 		const { response, story } = await getBabbelStory(storyID);
 		expect(response.status()).toBe(200);
 		expect(story?.title).toBe(originalTitle);
@@ -124,7 +106,6 @@ test.describe.serial('WordPress redacteursflow', () => {
 		await page.locator('#content').fill(updatedContent);
 		await savePost(page);
 
-		await loginToBabbel();
 		const { response, story } = await getBabbelStory(storyID);
 		expect(response.status()).toBe(200);
 		expect(story?.title).toBe(updatedTitle);
@@ -141,7 +122,6 @@ test.describe.serial('WordPress redacteursflow', () => {
 		await savePost(page);
 		await expect(page.locator('.knabbel-status-badge.deleted')).toBeVisible();
 
-		await loginToBabbel();
 		let remote = await getBabbelStory(storyID);
 		expect(remote.response.status()).toBe(404);
 
@@ -183,7 +163,7 @@ test.describe.serial('WordPress redacteursflow', () => {
 
 		await savePost(page);
 		const scheduledPostID = currentPostID(page);
-		let result = await inspectStory(page, scheduledPostID);
+		let result = await controlStory(page, scheduledPostID, 'inspect');
 		expect(result.pending).toBe(1);
 		expect(result.state.status).toBe('scheduled');
 
@@ -193,11 +173,10 @@ test.describe.serial('WordPress redacteursflow', () => {
 		await page.locator('.save-post-status').click({ force: true });
 		await savePost(page);
 
-		result = await inspectStory(page, scheduledPostID);
+		result = await controlStory(page, scheduledPostID, 'inspect');
 		expect(result.pending).toBe(0);
 		expect(result.state).toEqual([]);
 
-		await loginToBabbel();
 		expect(await countBabbelStoriesByTitle(scheduledTitle)).toBe(0);
 	});
 
@@ -210,7 +189,6 @@ test.describe.serial('WordPress redacteursflow', () => {
 			page.locator('#delete-action .submitdelete').click(),
 		]);
 
-		await loginToBabbel();
 		let remote = await getBabbelStory(storyID);
 		expect(remote.response.status()).toBe(404);
 

--- a/tests/playwright/editor-flow.spec.ts
+++ b/tests/playwright/editor-flow.spec.ts
@@ -68,7 +68,9 @@ test.describe.serial('WordPress redacteursflow', () => {
 		}
 
 		await Promise.all([
-			page.waitForNavigation(),
+			page.waitForURL(
+				/\/wp-admin\/options-general\.php\?page=zw-knabbel-wp-settings/,
+			),
 			page.locator('button[form="knabbel-settings-form"]').click(),
 		]);
 		await expect(
@@ -204,7 +206,7 @@ test.describe.serial('WordPress redacteursflow', () => {
 	}) => {
 		await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
 		await Promise.all([
-			page.waitForNavigation(),
+			page.waitForURL(/\/wp-admin\/edit\.php/),
 			page.locator('#delete-action .submitdelete').click(),
 		]);
 

--- a/tests/playwright/editor-flow.spec.ts
+++ b/tests/playwright/editor-flow.spec.ts
@@ -1,212 +1,261 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 import {
-	BABBEL_ADMIN,
-	controlStory,
-	countBabbelStoriesByTitle,
-	currentPostID,
-	getBabbelStory,
-	savePost,
-	setBabbelEnabled,
+    BABBEL_ADMIN,
+    controlStory,
+    countBabbelStoriesByTitle,
+    currentPostID,
+    disposeBabbelContext,
+    getBabbelStory,
+    savePost,
+    setBabbelEnabled,
+    updateBabbelStory,
 } from './utils';
 
 const runID = Date.now().toString();
 const originalTitle = `Browser E2E bericht ${runID}`;
 const updatedTitle = `${originalTitle} bijgewerkt`;
 const originalContent =
-	'Dit artikel wordt volledig via de WordPress-editor gepubliceerd en naar Babbel gestuurd.';
+    'Dit artikel wordt volledig via de WordPress-editor gepubliceerd en naar Babbel gestuurd.';
 const updatedContent =
-	'De redacteur heeft de inhoud via de WordPress-editor aangepast.';
+    'De redacteur heeft de inhoud via de WordPress-editor aangepast.';
+// Keep in sync with the OpenAI MU plugin and tests/e2e/suite.php.
+const generatedText = 'Deterministische E2E-radiospreektekst.';
+const editedText =
+    'Dit is een handmatig aangepaste E2E-radiospreektekst die behouden moet blijven.';
 
-test.describe.serial('WordPress redacteursflow', () => {
-	let postID = 0;
-	let storyID = '';
-	let generatedText = '';
+test.describe
+    .serial('WordPress redacteursflow', () => {
+        let postID = 0;
+        let storyID = '';
 
-	test('beheerder configureert en test de integratie via Instellingen', async ({
-		page,
-	}) => {
-		await page.goto(
-			'/wp-admin/options-general.php?page=zw-knabbel-wp-settings',
-		);
+        test.afterAll(async () => {
+            await disposeBabbelContext();
+        });
 
-		const settings = {
-			api_base_url: 'http://babbel:8080/api/v1',
-			api_username: BABBEL_ADMIN.username,
-			api_password: BABBEL_ADMIN.password,
-			openai_api_key: 'e2e-openai-key',
-			openai_model: 'e2e-model',
-			few_shot_count: '1',
-			start_days_offset: '1',
-			end_days_offset: '2',
-		};
-		for (const [key, value] of Object.entries(settings)) {
-			await page.locator(`[name="knabbel_settings[${key}]"]`).fill(value);
-		}
+        test('beheerder configureert en test de integratie via Instellingen', async ({
+            page,
+        }) => {
+            await page.goto(
+                '/wp-admin/options-general.php?page=zw-knabbel-wp-settings',
+            );
 
-		const debugMode = page.locator(
-			'[name="knabbel_settings[debug_mode]"]',
-		);
-		if (!(await debugMode.isChecked())) {
-			await page.getByText('Enable Debug Mode', { exact: true }).click();
-		}
+            const settings = {
+                api_base_url: 'http://babbel:8080/api/v1',
+                api_username: BABBEL_ADMIN.username,
+                api_password: BABBEL_ADMIN.password,
+                openai_api_key: 'e2e-openai-key',
+                openai_model: 'e2e-model',
+                few_shot_count: '1',
+                start_days_offset: '1',
+                end_days_offset: '2',
+            };
+            for (const [key, value] of Object.entries(settings)) {
+                await page
+                    .locator(`[name="knabbel_settings[${key}]"]`)
+                    .fill(value);
+            }
 
-		await Promise.all([
-			page.waitForURL(
-				/\/wp-admin\/options-general\.php\?page=zw-knabbel-wp-settings/,
-			),
-			page.locator('button[form="knabbel-settings-form"]').click(),
-		]);
-		await expect(
-			page.locator('[name="knabbel_settings[api_base_url]"]'),
-		).toHaveValue('http://babbel:8080/api/v1');
-		await expect(debugMode).toBeChecked();
+            const debugMode = page.locator(
+                '[name="knabbel_settings[debug_mode]"]',
+            );
+            if (!(await debugMode.isChecked())) {
+                await page
+                    .getByText('Enable Debug Mode', { exact: true })
+                    .click();
+            }
 
-		// The button's `transition: all` keeps Playwright's stability check waiting.
-		await page.locator('#test-babbel-api').click({ force: true });
-		await expect(page.locator('#api-test-result')).toContainText(/admin/i);
-	});
+            await Promise.all([
+                page.waitForURL(
+                    /\/wp-admin\/options-general\.php\?page=zw-knabbel-wp-settings/,
+                ),
+                page.locator('button[form="knabbel-settings-form"]').click(),
+            ]);
+            await expect(
+                page.locator('[name="knabbel_settings[api_base_url]"]'),
+            ).toHaveValue('http://babbel:8080/api/v1');
+            await expect(debugMode).toBeChecked();
 
-	test('redacteur publiceert een bericht en laat de wachtrij het naar Babbel sturen', async ({
-		page,
-	}) => {
-		await page.goto('/wp-admin/post-new.php');
-		await page.locator('#title').fill(originalTitle);
-		await page.locator('#content-html').click();
-		await page.locator('#content').fill(originalContent);
-		await setBabbelEnabled(page, true);
+            // The button's `transition: all` keeps Playwright's stability check waiting.
+            await page.locator('#test-babbel-api').click({ force: true });
+            await expect(page.locator('#api-test-result')).toHaveClass(
+                /success/,
+            );
+            await expect(page.locator('#api-test-result')).toContainText(
+                /admin/i,
+            );
+        });
 
-		await savePost(page);
-		postID = currentPostID(page);
-		await expect(page.locator('.knabbel-status-badge.scheduled')).toBeVisible();
+        test('redacteur publiceert een bericht en laat de wachtrij het naar Babbel sturen', async ({
+            page,
+        }) => {
+            await page.goto('/wp-admin/post-new.php');
+            await page.locator('#title').fill(originalTitle);
+            await page.locator('#content-html').click();
+            await page.locator('#content').fill(originalContent);
+            await setBabbelEnabled(page, true);
 
-		const result = await controlStory(page, postID, 'run');
-		expect(result.pending).toBe(0);
-		expect(result.state.status).toBe('sent');
-		expect(result.state.story_id).toBeTruthy();
-		storyID = result.state.story_id || '';
-		generatedText = result.state.generated_speech_text || '';
+            await savePost(page);
+            postID = currentPostID(page);
+            await expect(
+                page.locator('.knabbel-status-badge.scheduled'),
+            ).toBeVisible();
 
-		await page.reload();
-		await expect(page.locator('.knabbel-status-badge.sent')).toBeVisible();
-		await expect(page.locator('#knabbel_send_to_babbel')).toBeChecked();
+            const result = await controlStory(page, postID, 'run');
+            expect(result.pending).toBe(0);
+            expect(result.state.status).toBe('sent');
+            expect(result.state.story_id).toBeTruthy();
+            storyID = result.state.story_id || '';
+            expect(result.processed).toBe(1);
+            expect(result.state.generated_speech_text).toBe(generatedText);
 
-		const { response, story } = await getBabbelStory(storyID);
-		expect(response.status()).toBe(200);
-		expect(story?.title).toBe(originalTitle);
-		expect(story?.text).toBe('Deterministische E2E-radiospreektekst.');
-		expect(story?.metadata?.wordpress_id).toBe(postID);
-	});
+            await page.reload();
+            await expect(
+                page.locator('.knabbel-status-badge.sent'),
+            ).toBeVisible();
+            await expect(page.locator('#knabbel_send_to_babbel')).toBeChecked();
 
-	test('redacteur bewerkt titel en inhoud zonder bestaande spreektekst te overschrijven', async ({
-		page,
-	}) => {
-		await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
-		await page.locator('#title').fill(updatedTitle);
-		await page.locator('#content-html').click();
-		await page.locator('#content').fill(updatedContent);
-		await savePost(page);
+            const { response, story } = await getBabbelStory(storyID);
+            expect(response.status()).toBe(200);
+            expect(story?.title).toBe(originalTitle);
+            expect(story?.text).toBe(generatedText);
+            expect(story?.metadata?.wordpress_id).toBe(postID);
+        });
 
-		const { response, story } = await getBabbelStory(storyID);
-		expect(response.status()).toBe(200);
-		expect(story?.title).toBe(updatedTitle);
-		expect(story?.text).toBe(generatedText);
-		await expect(page.locator('#title')).toHaveValue(updatedTitle);
-		await expect(page.locator('#content')).toHaveValue(updatedContent);
-	});
+        test('redacteur bewerkt titel en inhoud zonder bestaande spreektekst te overschrijven', async ({
+            page,
+        }) => {
+            const before = await getBabbelStory(storyID);
+            expect(before.response.status()).toBe(200);
+            const updateResponse = await updateBabbelStory(storyID, {
+                text: editedText,
+                status: before.story?.status || 'draft',
+            });
+            expect(updateResponse.status(), await updateResponse.text()).toBe(
+                200,
+            );
 
-	test('redacteur schakelt Babbel uit en herstelt daarna hetzelfde verhaal', async ({
-		page,
-	}) => {
-		await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
-		await setBabbelEnabled(page, false);
-		await savePost(page);
-		await expect(page.locator('.knabbel-status-badge.deleted')).toBeVisible();
+            await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
+            await page.locator('#title').fill(updatedTitle);
+            await page.locator('#content-html').click();
+            await page.locator('#content').fill(updatedContent);
+            await savePost(page);
 
-		let remote = await getBabbelStory(storyID);
-		expect(remote.response.status()).toBe(404);
+            const { response, story } = await getBabbelStory(storyID);
+            expect(response.status()).toBe(200);
+            expect(story?.id).toBe(storyID);
+            expect(story?.title).toBe(updatedTitle);
+            expect(story?.text).toBe(editedText);
+            expect(await countBabbelStoriesByTitle(updatedTitle)).toBe(1);
+            await expect(page.locator('#title')).toHaveValue(updatedTitle);
+            await expect(page.locator('#content')).toHaveValue(updatedContent);
+        });
 
-		await page.reload();
-		await setBabbelEnabled(page, true);
-		await savePost(page);
-		await expect(page.locator('.knabbel-status-badge.sent')).toBeVisible();
+        test('redacteur schakelt Babbel uit en herstelt daarna hetzelfde verhaal', async ({
+            page,
+        }) => {
+            await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
+            await setBabbelEnabled(page, false);
+            await savePost(page);
+            await expect(
+                page.locator('.knabbel-status-badge.deleted'),
+            ).toBeVisible();
 
-		remote = await getBabbelStory(storyID);
-		expect(remote.response.status()).toBe(200);
-		expect(remote.story?.id).toBe(storyID);
-	});
+            let remote = await getBabbelStory(storyID);
+            expect(remote.response.status()).toBe(404);
 
-	test('redacteur plant een bericht en annuleert het voor verwerking', async ({
-		page,
-	}) => {
-		const scheduledTitle = `Browser E2E planning ${runID}`;
-		const publication = new Date();
-		publication.setDate(publication.getDate() + 10);
-		publication.setHours(12, 0, 0, 0);
+            await page.reload();
+            await setBabbelEnabled(page, true);
+            await savePost(page);
+            await expect(
+                page.locator('.knabbel-status-badge.sent'),
+            ).toBeVisible();
 
-		await page.goto('/wp-admin/post-new.php');
-		await page.locator('#title').fill(scheduledTitle);
-		await page.locator('#content-html').click();
-		await page.locator('#content').fill(originalContent);
-		await setBabbelEnabled(page, true);
-		await page.locator('.edit-timestamp').click();
-		await page
-			.locator('#mm')
-			.selectOption(String(publication.getMonth() + 1).padStart(2, '0'));
-		await page
-			.locator('#jj')
-			.fill(String(publication.getDate()).padStart(2, '0'));
-		await page.locator('#aa').fill(String(publication.getFullYear()));
-		await page.locator('#hh').fill('12');
-		await page.locator('#mn').fill('00');
-		await page.locator('.save-timestamp').click();
-		await expect(page.locator('#publish')).toHaveValue('Schedule');
+            remote = await getBabbelStory(storyID);
+            expect(remote.response.status()).toBe(200);
+            expect(remote.story?.id).toBe(storyID);
+        });
 
-		await savePost(page);
-		const scheduledPostID = currentPostID(page);
-		let result = await controlStory(page, scheduledPostID, 'inspect');
-		expect(result.pending).toBe(1);
-		expect(result.state.status).toBe('scheduled');
+        test('redacteur plant een bericht en annuleert het voor verwerking', async ({
+            page,
+        }) => {
+            const scheduledTitle = `Browser E2E planning ${runID}`;
+            const publication = new Date();
+            publication.setDate(publication.getDate() + 10);
+            publication.setHours(12, 0, 0, 0);
 
-		await page.locator('.edit-post-status').click({ force: true });
-		await expect(page.locator('#post_status')).toBeVisible();
-		await page.locator('#post_status').selectOption('draft');
-		await page.locator('.save-post-status').click({ force: true });
-		await savePost(page);
+            await page.goto('/wp-admin/post-new.php');
+            await page.locator('#title').fill(scheduledTitle);
+            await page.locator('#content-html').click();
+            await page.locator('#content').fill(originalContent);
+            await setBabbelEnabled(page, true);
+            await page.locator('.edit-timestamp').click();
+            await page
+                .locator('#mm')
+                .selectOption(
+                    String(publication.getMonth() + 1).padStart(2, '0'),
+                );
+            await page
+                .locator('#jj')
+                .fill(String(publication.getDate()).padStart(2, '0'));
+            await page.locator('#aa').fill(String(publication.getFullYear()));
+            await page.locator('#hh').fill('12');
+            await page.locator('#mn').fill('00');
+            await page.locator('.save-timestamp').click();
+            await expect(page.locator('#publish')).toHaveValue('Schedule');
 
-		result = await controlStory(page, scheduledPostID, 'inspect');
-		expect(result.pending).toBe(0);
-		expect(result.state).toEqual([]);
+            await savePost(page);
+            const scheduledPostID = currentPostID(page);
+            let result = await controlStory(page, scheduledPostID, 'inspect');
+            expect(result.pending).toBe(1);
+            expect(result.state.status).toBe('scheduled');
 
-		expect(await countBabbelStoriesByTitle(scheduledTitle)).toBe(0);
-	});
+            const postStatus = page.locator('#post_status');
+            await expect(async () => {
+                if (!(await postStatus.isVisible())) {
+                    await page.locator('.edit-post-status').click();
+                }
+                await expect(postStatus).toBeVisible({ timeout: 1_000 });
+            }).toPass({ timeout: 15_000 });
+            await postStatus.selectOption('draft');
+            await page.locator('.save-post-status').click();
+            await savePost(page);
 
-	test('redacteur verplaatst het bericht naar de prullenbak en herstelt het', async ({
-		page,
-	}) => {
-		await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
-		await Promise.all([
-			page.waitForURL(/\/wp-admin\/edit\.php/),
-			page.locator('#delete-action .submitdelete').click(),
-		]);
+            result = await controlStory(page, scheduledPostID, 'inspect');
+            expect(result.pending).toBe(0);
+            expect(result.state).toEqual({});
 
-		let remote = await getBabbelStory(storyID);
-		expect(remote.response.status()).toBe(404);
+            expect(await countBabbelStoriesByTitle(scheduledTitle)).toBe(0);
+        });
 
-		await page.goto('/wp-admin/edit.php?post_status=trash&post_type=post');
-		const row = page.locator('tr', {
-			has: page.getByText(updatedTitle, { exact: true }),
-		});
-		await expect(row).toBeVisible();
-		const restoreURL = await row
-			.getByRole('link', { name: /^Restore .* from the Trash$/ })
-			.getAttribute('href');
-		expect(restoreURL).toBeTruthy();
-		await page.goto(restoreURL || '');
-		await expect(page).toHaveURL(/\/wp-admin\/edit\.php/);
+        test('redacteur verplaatst het bericht naar de prullenbak en herstelt het', async ({
+            page,
+        }) => {
+            await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
+            await Promise.all([
+                page.waitForURL(/\/wp-admin\/edit\.php/),
+                page.locator('#delete-action .submitdelete').click(),
+            ]);
 
-		remote = await getBabbelStory(storyID);
-		expect(remote.response.status()).toBe(200);
-		expect(remote.story?.id).toBe(storyID);
-		expect(remote.story?.title).toBe(updatedTitle);
-	});
-});
+            let remote = await getBabbelStory(storyID);
+            expect(remote.response.status()).toBe(404);
+
+            await page.goto(
+                '/wp-admin/edit.php?post_status=trash&post_type=post',
+            );
+            const row = page.locator('tr', {
+                has: page.getByText(updatedTitle, { exact: true }),
+            });
+            await expect(row).toBeVisible();
+            const restoreURL = await row
+                .getByRole('link', { name: /^Restore .* from the Trash$/ })
+                .getAttribute('href');
+            expect(restoreURL).toBeTruthy();
+            await page.goto(restoreURL || '');
+            await expect(page).toHaveURL(/\/wp-admin\/edit\.php/);
+
+            remote = await getBabbelStory(storyID);
+            expect(remote.response.status()).toBe(200);
+            expect(remote.story?.id).toBe(storyID);
+            expect(remote.story?.title).toBe(updatedTitle);
+        });
+    });

--- a/tests/playwright/editor-flow.spec.ts
+++ b/tests/playwright/editor-flow.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from './fixtures';
 import {
     BABBEL_ADMIN,
+    babbelStoryStatus,
     controlStory,
     countBabbelStoriesByTitle,
     currentPostID,
@@ -114,21 +115,19 @@ test.describe
             ).toBeVisible();
             await expect(page.locator('#knabbel_send_to_babbel')).toBeChecked();
 
-            const { response, story } = await getBabbelStory(storyID);
-            expect(response.status()).toBe(200);
-            expect(story?.title).toBe(originalTitle);
-            expect(story?.text).toBe(generatedText);
-            expect(story?.metadata?.wordpress_id).toBe(postID);
+            const story = await getBabbelStory(storyID);
+            expect(story.title).toBe(originalTitle);
+            expect(story.text).toBe(generatedText);
+            expect(story.metadata?.wordpress_id).toBe(postID);
         });
 
         test('redacteur bewerkt titel en inhoud zonder bestaande spreektekst te overschrijven', async ({
             page,
         }) => {
             const before = await getBabbelStory(storyID);
-            expect(before.response.status()).toBe(200);
             const updateResponse = await updateBabbelStory(storyID, {
                 text: editedText,
-                status: before.story?.status || 'draft',
+                status: before.status || 'draft',
             });
             expect(updateResponse.status(), await updateResponse.text()).toBe(
                 200,
@@ -140,11 +139,10 @@ test.describe
             await page.locator('#content').fill(updatedContent);
             await savePost(page);
 
-            const { response, story } = await getBabbelStory(storyID);
-            expect(response.status()).toBe(200);
-            expect(story?.id).toBe(storyID);
-            expect(story?.title).toBe(updatedTitle);
-            expect(story?.text).toBe(editedText);
+            const story = await getBabbelStory(storyID);
+            expect(story.id).toBe(storyID);
+            expect(story.title).toBe(updatedTitle);
+            expect(story.text).toBe(editedText);
             expect(await countBabbelStoriesByTitle(updatedTitle)).toBe(1);
             await expect(page.locator('#title')).toHaveValue(updatedTitle);
             await expect(page.locator('#content')).toHaveValue(updatedContent);
@@ -160,8 +158,7 @@ test.describe
                 page.locator('.knabbel-status-badge.deleted'),
             ).toBeVisible();
 
-            let remote = await getBabbelStory(storyID);
-            expect(remote.response.status()).toBe(404);
+            expect(await babbelStoryStatus(storyID)).toBe(404);
 
             await page.reload();
             await setBabbelEnabled(page, true);
@@ -170,9 +167,7 @@ test.describe
                 page.locator('.knabbel-status-badge.sent'),
             ).toBeVisible();
 
-            remote = await getBabbelStory(storyID);
-            expect(remote.response.status()).toBe(200);
-            expect(remote.story?.id).toBe(storyID);
+            expect((await getBabbelStory(storyID)).id).toBe(storyID);
         });
 
         test('redacteur plant een bericht en annuleert het voor verwerking', async ({
@@ -211,26 +206,15 @@ test.describe
 
             // WordPress uses jQuery slide animations for these classic-editor
             // controls. Chromium can leave them at a fractional pixel in CI.
-            await page.evaluate(() => {
-                const jquery = (
-                    window as typeof window & {
-                        jQuery: { fx: { off: boolean } };
-                    }
-                ).jQuery;
-                jquery.fx.off = true;
-            });
+            await page.evaluate('jQuery.fx.off = true');
+            // WordPress hides #post_status behind the Edit link whenever JS is on.
+            // These jQuery-animated links never settle into Playwright's stable
+            // state, so dispatch the click instead of waiting for actionability.
             const postStatus = page.locator('#post_status');
-            if (!(await postStatus.isVisible())) {
-                await page
-                    .locator('.edit-post-status')
-                    .evaluate((link: HTMLAnchorElement) => link.click());
-            }
+            await page.locator('.edit-post-status').dispatchEvent('click');
             await expect(postStatus).toBeVisible();
             await postStatus.selectOption('draft');
-            await expect(postStatus).toHaveValue('draft');
-            await page
-                .locator('.save-post-status')
-                .evaluate((link: HTMLAnchorElement) => link.click());
+            await page.locator('.save-post-status').dispatchEvent('click');
             await expect(postStatus).toBeHidden();
             await savePost(page);
 
@@ -245,15 +229,14 @@ test.describe
             page,
         }) => {
             await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
-            const trashLink = page.locator('#delete-action .submitdelete');
-            await expect(trashLink).toBeVisible();
             await Promise.all([
                 page.waitForURL(/\/wp-admin\/edit\.php/),
-                trashLink.evaluate((link: HTMLAnchorElement) => link.click()),
+                page
+                    .locator('#delete-action .submitdelete')
+                    .dispatchEvent('click'),
             ]);
 
-            let remote = await getBabbelStory(storyID);
-            expect(remote.response.status()).toBe(404);
+            expect(await babbelStoryStatus(storyID)).toBe(404);
 
             await page.goto(
                 '/wp-admin/edit.php?post_status=trash&post_type=post',
@@ -261,7 +244,8 @@ test.describe
             const row = page.locator('tr', {
                 has: page.getByText(updatedTitle, { exact: true }),
             });
-            await expect(row).toBeVisible();
+            // Row actions stay hidden until the row is hovered, and the trash list is
+            // already on edit.php, so follow the restore URL as its own navigation.
             const restoreURL = await row
                 .getByRole('link', { name: /^Restore .* from the Trash$/ })
                 .getAttribute('href');
@@ -269,9 +253,8 @@ test.describe
             await page.goto(restoreURL || '');
             await expect(page).toHaveURL(/\/wp-admin\/edit\.php/);
 
-            remote = await getBabbelStory(storyID);
-            expect(remote.response.status()).toBe(200);
-            expect(remote.story?.id).toBe(storyID);
-            expect(remote.story?.title).toBe(updatedTitle);
+            const story = await getBabbelStory(storyID);
+            expect(story.id).toBe(storyID);
+            expect(story.title).toBe(updatedTitle);
         });
     });

--- a/tests/playwright/editor-flow.spec.ts
+++ b/tests/playwright/editor-flow.spec.ts
@@ -209,15 +209,29 @@ test.describe
             expect(result.pending).toBe(1);
             expect(result.state.status).toBe('scheduled');
 
+            // WordPress uses jQuery slide animations for these classic-editor
+            // controls. Chromium can leave them at a fractional pixel in CI.
+            await page.evaluate(() => {
+                const jquery = (
+                    window as typeof window & {
+                        jQuery: { fx: { off: boolean } };
+                    }
+                ).jQuery;
+                jquery.fx.off = true;
+            });
             const postStatus = page.locator('#post_status');
-            await expect(async () => {
-                if (!(await postStatus.isVisible())) {
-                    await page.locator('.edit-post-status').click();
-                }
-                await expect(postStatus).toBeVisible({ timeout: 1_000 });
-            }).toPass({ timeout: 15_000 });
+            if (!(await postStatus.isVisible())) {
+                await page
+                    .locator('.edit-post-status')
+                    .evaluate((link: HTMLAnchorElement) => link.click());
+            }
+            await expect(postStatus).toBeVisible();
             await postStatus.selectOption('draft');
-            await page.locator('.save-post-status').click();
+            await expect(postStatus).toHaveValue('draft');
+            await page
+                .locator('.save-post-status')
+                .evaluate((link: HTMLAnchorElement) => link.click());
+            await expect(postStatus).toBeHidden();
             await savePost(page);
 
             result = await controlStory(page, scheduledPostID, 'inspect');
@@ -231,9 +245,11 @@ test.describe
             page,
         }) => {
             await page.goto(`/wp-admin/post.php?post=${postID}&action=edit`);
+            const trashLink = page.locator('#delete-action .submitdelete');
+            await expect(trashLink).toBeVisible();
             await Promise.all([
                 page.waitForURL(/\/wp-admin\/edit\.php/),
-                page.locator('#delete-action .submitdelete').click(),
+                trashLink.evaluate((link: HTMLAnchorElement) => link.click()),
             ]);
 
             let remote = await getBabbelStory(storyID);

--- a/tests/playwright/fixtures.ts
+++ b/tests/playwright/fixtures.ts
@@ -9,6 +9,11 @@ interface BrowserErrorFixtures {
     browserErrors: string[];
 }
 
+const allowedBrowserErrors = [
+    // WordPress admin navigation can skip Chrome View Transitions without affecting the page update.
+    /^pageerror: Transition was skipped$/,
+];
+
 function collectBrowserErrors(page: Page, errors: string[]): void {
     page.on('pageerror', (error) => {
         errors.push(`pageerror: ${error.message}`);
@@ -28,9 +33,16 @@ export const test = base.extend<BrowserErrorFixtures>({
             const errors: string[] = [];
             collectBrowserErrors(page, errors);
             await use(errors);
-            expect(errors, 'Browser JavaScript errors must be empty.').toEqual(
-                [],
+            const unexpectedErrors = errors.filter(
+                (error) =>
+                    !allowedBrowserErrors.some((pattern) =>
+                        pattern.test(error),
+                    ),
             );
+            expect(
+                unexpectedErrors,
+                'Unexpected browser JavaScript errors must be empty.',
+            ).toEqual([]);
         },
         { auto: true },
     ],

--- a/tests/playwright/fixtures.ts
+++ b/tests/playwright/fixtures.ts
@@ -1,0 +1,37 @@
+import {
+    test as base,
+    type ConsoleMessage,
+    expect,
+    type Page,
+} from '@playwright/test';
+
+interface BrowserErrorFixtures {
+    browserErrors: string[];
+}
+
+function collectBrowserErrors(page: Page, errors: string[]): void {
+    page.on('pageerror', (error) => {
+        errors.push(`pageerror: ${error.message}`);
+    });
+    page.on('console', (message: ConsoleMessage) => {
+        if (message.type() === 'error') {
+            errors.push(`console.error: ${message.text()}`);
+        }
+    });
+}
+
+export { expect };
+
+export const test = base.extend<BrowserErrorFixtures>({
+    browserErrors: [
+        async ({ page }, use) => {
+            const errors: string[] = [];
+            collectBrowserErrors(page, errors);
+            await use(errors);
+            expect(errors, 'Browser JavaScript errors must be empty.').toEqual(
+                [],
+            );
+        },
+        { auto: true },
+    ],
+});

--- a/tests/playwright/fixtures.ts
+++ b/tests/playwright/fixtures.ts
@@ -1,46 +1,34 @@
-import {
-    test as base,
-    type ConsoleMessage,
-    expect,
-    type Page,
-} from '@playwright/test';
-
-interface BrowserErrorFixtures {
-    browserErrors: string[];
-}
+import { test as base, expect } from '@playwright/test';
 
 const allowedBrowserErrors = [
     // WordPress admin navigation can skip Chrome View Transitions without affecting the page update.
     /^pageerror: Transition was skipped$/,
 ];
 
-function collectBrowserErrors(page: Page, errors: string[]): void {
-    page.on('pageerror', (error) => {
-        errors.push(`pageerror: ${error.message}`);
-    });
-    page.on('console', (message: ConsoleMessage) => {
-        if (message.type() === 'error') {
-            errors.push(`console.error: ${message.text()}`);
-        }
-    });
-}
-
 export { expect };
 
-export const test = base.extend<BrowserErrorFixtures>({
-    browserErrors: [
+export const test = base.extend<{ assertNoBrowserErrors: undefined }>({
+    assertNoBrowserErrors: [
         async ({ page }, use) => {
             const errors: string[] = [];
-            collectBrowserErrors(page, errors);
-            await use(errors);
-            const unexpectedErrors = errors.filter(
-                (error) =>
-                    !allowedBrowserErrors.some((pattern) =>
-                        pattern.test(error),
-                    ),
+            page.on('pageerror', (error) =>
+                errors.push(`pageerror: ${error.message}`),
             );
+            page.on('console', (message) => {
+                if (message.type() === 'error') {
+                    errors.push(`console.error: ${message.text()}`);
+                }
+            });
+
+            await use(undefined);
+
             expect(
-                unexpectedErrors,
+                errors.filter(
+                    (error) =>
+                        !allowedBrowserErrors.some((pattern) =>
+                            pattern.test(error),
+                        ),
+                ),
                 'Unexpected browser JavaScript errors must be empty.',
             ).toEqual([]);
         },

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -26,13 +26,16 @@ export interface BabbelStory {
 	};
 }
 
+export const WP_ADMIN = { username: 'admin', password: 'e2e-admin-password' };
+export const BABBEL_ADMIN = { username: 'admin', password: 'admin' };
+
 const babbelURL = process.env.PLAYWRIGHT_BABBEL_URL;
 let babbelContext: APIRequestContext | undefined;
 
 export async function login(page: Page): Promise<void> {
 	await page.goto('/wp-login.php');
-	await page.getByLabel('Username or Email Address').fill('admin');
-	await page.getByLabel('Password', { exact: true }).fill('e2e-admin-password');
+	await page.getByLabel('Username or Email Address').fill(WP_ADMIN.username);
+	await page.getByLabel('Password', { exact: true }).fill(WP_ADMIN.password);
 	await page.getByRole('button', { name: 'Log In' }).click();
 	await expect(page).toHaveURL(/\/wp-admin\//);
 }
@@ -74,29 +77,10 @@ export async function setBabbelEnabled(
 		'.knabbel-radionieuws-injected #knabbel_send_to_babbel',
 	);
 	await expect(checkbox).toBeVisible();
-
-	if (enabled) {
-		await checkbox.check({ force: true });
-	} else {
-		await checkbox.uncheck({ force: true });
-	}
+	await checkbox.setChecked(enabled, { force: true });
 }
 
-export async function runStoryActions(
-	page: Page,
-	postID: number,
-): Promise<ControlResult> {
-	return controlStory(page, postID, 'run');
-}
-
-export async function inspectStory(
-	page: Page,
-	postID: number,
-): Promise<ControlResult> {
-	return controlStory(page, postID, 'inspect');
-}
-
-async function controlStory(
+export async function controlStory(
 	page: Page,
 	postID: number,
 	operation: 'inspect' | 'run',
@@ -111,7 +95,7 @@ async function controlStory(
 		},
 	});
 
-	expect(response.status()).toBe(200);
+	expect(response.status(), await response.text()).toBe(200);
 	const body = (await response.json()) as {
 		success: boolean;
 		data: ControlResult;
@@ -119,17 +103,6 @@ async function controlStory(
 	expect(body.success).toBe(true);
 
 	return body.data;
-}
-
-export async function loginToBabbel(): Promise<void> {
-	const response = await babbelRequest('/sessions', {
-		method: 'POST',
-		data: {
-			username: 'admin',
-			password: 'admin',
-		},
-	});
-	expect(response.status()).toBe(201);
 }
 
 export async function getBabbelStory(
@@ -170,7 +143,11 @@ async function babbelRequest(
 	}
 
 	if (!babbelContext) {
-		babbelContext = await request.newContext({ baseURL: babbelURL });
+		babbelContext = await request.newContext();
+		const session = await babbelContext.post(`${babbelURL}/sessions`, {
+			data: BABBEL_ADMIN,
+		});
+		expect(session.status()).toBe(201);
 	}
 
 	return babbelContext.fetch(`${babbelURL}${path}`, options);

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -1,0 +1,177 @@
+import {
+	expect,
+	request,
+	type APIRequestContext,
+	type APIResponse,
+	type Page,
+} from '@playwright/test';
+
+export interface StoryState {
+	status?: string;
+	story_id?: string;
+	generated_speech_text?: string;
+}
+
+export interface ControlResult {
+	pending: number;
+	state: StoryState;
+}
+
+export interface BabbelStory {
+	id: string;
+	title: string;
+	text: string;
+	metadata?: {
+		wordpress_id?: number;
+	};
+}
+
+const babbelURL = process.env.PLAYWRIGHT_BABBEL_URL;
+let babbelContext: APIRequestContext | undefined;
+
+export async function login(page: Page): Promise<void> {
+	await page.goto('/wp-login.php');
+	await page.getByLabel('Username or Email Address').fill('admin');
+	await page.getByLabel('Password', { exact: true }).fill('e2e-admin-password');
+	await page.getByRole('button', { name: 'Log In' }).click();
+	await expect(page).toHaveURL(/\/wp-admin\//);
+}
+
+export async function savePost(page: Page): Promise<void> {
+	const postResponse = page.waitForResponse(
+		(response) =>
+			response.request().method() === 'POST' &&
+			new URL(response.url()).pathname === '/wp-admin/post.php',
+	);
+	const navigation = page.waitForEvent(
+		'framenavigated',
+		(frame) => frame === page.mainFrame(),
+	);
+
+	await Promise.all([
+		postResponse,
+		navigation,
+		page.locator('#publish').evaluate((button: HTMLInputElement) => {
+			button.form?.requestSubmit(button);
+		}),
+	]);
+	await expect(page).toHaveURL(/\/wp-admin\/post\.php\?post=\d+&action=edit/);
+	await expect(page.locator('#publish')).toBeVisible();
+}
+
+export function currentPostID(page: Page): number {
+	const postID = Number(new URL(page.url()).searchParams.get('post'));
+	expect(postID).toBeGreaterThan(0);
+
+	return postID;
+}
+
+export async function setBabbelEnabled(
+	page: Page,
+	enabled: boolean,
+): Promise<void> {
+	const checkbox = page.locator(
+		'.knabbel-radionieuws-injected #knabbel_send_to_babbel',
+	);
+	await expect(checkbox).toBeVisible();
+
+	if (enabled) {
+		await checkbox.check({ force: true });
+	} else {
+		await checkbox.uncheck({ force: true });
+	}
+}
+
+export async function runStoryActions(
+	page: Page,
+	postID: number,
+): Promise<ControlResult> {
+	return controlStory(page, postID, 'run');
+}
+
+export async function inspectStory(
+	page: Page,
+	postID: number,
+): Promise<ControlResult> {
+	return controlStory(page, postID, 'inspect');
+}
+
+async function controlStory(
+	page: Page,
+	postID: number,
+	operation: 'inspect' | 'run',
+): Promise<ControlResult> {
+	const nonce = await page.locator('#knabbel_nonce').inputValue();
+	const response = await page.request.post('/wp-admin/admin-ajax.php', {
+		form: {
+			action: 'knabbel_e2e_control',
+			nonce,
+			operation,
+			post_id: String(postID),
+		},
+	});
+
+	expect(response.status()).toBe(200);
+	const body = (await response.json()) as {
+		success: boolean;
+		data: ControlResult;
+	};
+	expect(body.success).toBe(true);
+
+	return body.data;
+}
+
+export async function loginToBabbel(): Promise<void> {
+	const response = await babbelRequest('/sessions', {
+		method: 'POST',
+		data: {
+			username: 'admin',
+			password: 'admin',
+		},
+	});
+	expect(response.status()).toBe(201);
+}
+
+export async function getBabbelStory(
+	storyID: string,
+): Promise<{ response: APIResponse; story?: BabbelStory }> {
+	const response = await babbelRequest(`/stories/${encodeURIComponent(storyID)}`);
+
+	if (response.status() !== 200) {
+		return { response };
+	}
+
+	return {
+		response,
+		story: (await response.json()) as BabbelStory,
+	};
+}
+
+export async function countBabbelStoriesByTitle(
+	title: string,
+): Promise<number> {
+	const query = new URLSearchParams({
+		'filter[title]': title,
+		limit: '100',
+	});
+	const response = await babbelRequest(`/stories?${query.toString()}`);
+	expect(response.status()).toBe(200);
+	const body = (await response.json()) as { data?: BabbelStory[] };
+
+	return (body.data || []).filter((story) => story.title === title).length;
+}
+
+async function babbelRequest(
+	path: string,
+	options?: Parameters<APIRequestContext['fetch']>[1],
+): Promise<APIResponse> {
+	if (!babbelURL) {
+		throw new Error('PLAYWRIGHT_BABBEL_URL is required.');
+	}
+
+	if (!babbelContext) {
+		babbelContext = await request.newContext({ baseURL: babbelURL });
+	}
+
+	return babbelContext.fetch(`${babbelURL}${path}`, options);
+}

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -1,31 +1,34 @@
 import {
-	expect,
-	request,
-	type APIRequestContext,
-	type APIResponse,
-	type Page,
+    type APIRequestContext,
+    type APIResponse,
+    expect,
+    type Page,
+    request,
 } from '@playwright/test';
 
 export interface StoryState {
-	status?: string;
-	story_id?: string;
-	generated_speech_text?: string;
+    status?: string;
+    story_id?: string;
+    generated_speech_text?: string;
 }
 
 export interface ControlResult {
-	pending: number;
-	state: StoryState;
+    pending: number;
+    processed: number;
+    state: StoryState;
 }
 
 export interface BabbelStory {
-	id: string;
-	title: string;
-	text: string;
-	metadata?: {
-		wordpress_id?: number;
-	};
+    id: string;
+    title: string;
+    text: string;
+    status?: string;
+    metadata?: {
+        wordpress_id?: number;
+    };
 }
 
+// Keep these credentials in sync with tests/e2e/run.sh and suite.php.
 export const WP_ADMIN = { username: 'admin', password: 'e2e-admin-password' };
 export const BABBEL_ADMIN = { username: 'admin', password: 'admin' };
 
@@ -33,122 +36,164 @@ const babbelURL = process.env.PLAYWRIGHT_BABBEL_URL;
 let babbelContext: APIRequestContext | undefined;
 
 export async function login(page: Page): Promise<void> {
-	await page.goto('/wp-login.php');
-	await page.getByLabel('Username or Email Address').fill(WP_ADMIN.username);
-	await page.getByLabel('Password', { exact: true }).fill(WP_ADMIN.password);
-	await page.getByRole('button', { name: 'Log In' }).click();
-	await expect(page).toHaveURL(/\/wp-admin\//);
+    await page.goto('/wp-login.php');
+    await page.getByLabel('Username or Email Address').fill(WP_ADMIN.username);
+    await page.getByLabel('Password', { exact: true }).fill(WP_ADMIN.password);
+    await page.getByRole('button', { name: 'Log In' }).click();
+    await expect(page).toHaveURL(/\/wp-admin\//);
 }
 
 export async function savePost(page: Page): Promise<void> {
-	const postResponse = page.waitForResponse(
-		(response) =>
-			response.request().method() === 'POST' &&
-			new URL(response.url()).pathname === '/wp-admin/post.php',
-	);
-	const navigation = page.waitForEvent(
-		'framenavigated',
-		(frame) => frame === page.mainFrame(),
-	);
+    const postResponse = page.waitForResponse(
+        (response) =>
+            response.request().method() === 'POST' &&
+            new URL(response.url()).pathname === '/wp-admin/post.php',
+    );
+    const navigation = page.waitForEvent(
+        'framenavigated',
+        (frame) => frame === page.mainFrame(),
+    );
 
-	await Promise.all([
-		postResponse,
-		navigation,
-		page.locator('#publish').evaluate((button: HTMLInputElement) => {
-			button.form?.requestSubmit(button);
-		}),
-	]);
-	await expect(page).toHaveURL(/\/wp-admin\/post\.php\?post=\d+&action=edit/);
-	await expect(page.locator('#publish')).toBeVisible();
+    const [response] = await Promise.all([
+        postResponse,
+        navigation,
+        page.locator('#publish').evaluate((button: HTMLInputElement) => {
+            if (!button.form) {
+                throw new Error(
+                    'The publish button is not associated with a form.',
+                );
+            }
+            button.form.requestSubmit(button);
+        }),
+    ]);
+    expect(response.status(), await response.text()).toBeLessThan(400);
+    await expect(page).toHaveURL(/\/wp-admin\/post\.php\?post=\d+&action=edit/);
+    await expect(page.locator('#publish')).toBeVisible();
 }
 
 export function currentPostID(page: Page): number {
-	const postID = Number(new URL(page.url()).searchParams.get('post'));
-	expect(postID).toBeGreaterThan(0);
+    const postID = Number(new URL(page.url()).searchParams.get('post'));
+    expect(postID).toBeGreaterThan(0);
 
-	return postID;
+    return postID;
 }
 
 export async function setBabbelEnabled(
-	page: Page,
-	enabled: boolean,
+    page: Page,
+    enabled: boolean,
 ): Promise<void> {
-	const checkbox = page.locator(
-		'.knabbel-radionieuws-injected #knabbel_send_to_babbel',
-	);
-	await expect(checkbox).toBeVisible();
-	await checkbox.setChecked(enabled, { force: true });
+    const checkbox = page.locator(
+        '.knabbel-radionieuws-injected #knabbel_send_to_babbel',
+    );
+    await expect(checkbox).toBeVisible();
+    await checkbox.setChecked(enabled);
 }
 
 export async function controlStory(
-	page: Page,
-	postID: number,
-	operation: 'inspect' | 'run',
+    page: Page,
+    postID: number,
+    operation: 'inspect' | 'run',
 ): Promise<ControlResult> {
-	const nonce = await page.locator('#knabbel_nonce').inputValue();
-	const response = await page.request.post('/wp-admin/admin-ajax.php', {
-		form: {
-			action: 'knabbel_e2e_control',
-			nonce,
-			operation,
-			post_id: String(postID),
-		},
-	});
+    const nonce = await page.locator('#knabbel_nonce').inputValue();
+    const response = await page.request.post('/wp-admin/admin-ajax.php', {
+        form: {
+            action: 'knabbel_e2e_control',
+            nonce,
+            operation,
+            post_id: String(postID),
+        },
+    });
 
-	expect(response.status(), await response.text()).toBe(200);
-	const body = (await response.json()) as {
-		success: boolean;
-		data: ControlResult;
-	};
-	expect(body.success).toBe(true);
+    expect(response.status(), await response.text()).toBe(200);
+    const body = (await response.json()) as {
+        success: boolean;
+        data: ControlResult;
+    };
+    expect(body.success).toBe(true);
 
-	return body.data;
+    return body.data;
 }
 
 export async function getBabbelStory(
-	storyID: string,
+    storyID: string,
 ): Promise<{ response: APIResponse; story?: BabbelStory }> {
-	const response = await babbelRequest(`/stories/${encodeURIComponent(storyID)}`);
+    const response = await babbelRequest(
+        `/stories/${encodeURIComponent(storyID)}`,
+    );
 
-	if (response.status() !== 200) {
-		return { response };
-	}
+    if (response.status() !== 200) {
+        return { response };
+    }
 
-	return {
-		response,
-		story: (await response.json()) as BabbelStory,
-	};
+    return {
+        response,
+        story: (await response.json()) as BabbelStory,
+    };
+}
+
+export async function updateBabbelStory(
+    storyID: string,
+    data: { text: string; status: string },
+): Promise<APIResponse> {
+    return babbelRequest(`/stories/${encodeURIComponent(storyID)}`, {
+        method: 'PUT',
+        data,
+    });
 }
 
 export async function countBabbelStoriesByTitle(
-	title: string,
+    title: string,
 ): Promise<number> {
-	const query = new URLSearchParams({
-		'filter[title]': title,
-		limit: '100',
-	});
-	const response = await babbelRequest(`/stories?${query.toString()}`);
-	expect(response.status()).toBe(200);
-	const body = (await response.json()) as { data?: BabbelStory[] };
+    const query = new URLSearchParams({
+        'filter[title]': title,
+        limit: '100',
+    });
+    const response = await babbelRequest(`/stories?${query.toString()}`);
+    const rawBody = await response.text();
+    expect(response.status(), rawBody).toBe(200);
+    const body = JSON.parse(rawBody) as {
+        data?: unknown;
+        limit?: unknown;
+        offset?: unknown;
+        total?: unknown;
+    };
+    expect(Array.isArray(body.data), rawBody).toBe(true);
+    const stories = body.data as BabbelStory[];
+    expect(body.limit, rawBody).toBe(100);
+    expect(body.offset, rawBody).toBe(0);
+    expect(body.total, rawBody).toBe(stories.length);
+    expect(stories.length, rawBody).toBeLessThan(100);
 
-	return (body.data || []).filter((story) => story.title === title).length;
+    return stories.filter((story) => story.title === title).length;
+}
+
+export async function disposeBabbelContext(): Promise<void> {
+    await babbelContext?.dispose();
+    babbelContext = undefined;
 }
 
 async function babbelRequest(
-	path: string,
-	options?: Parameters<APIRequestContext['fetch']>[1],
+    path: string,
+    options?: Parameters<APIRequestContext['fetch']>[1],
 ): Promise<APIResponse> {
-	if (!babbelURL) {
-		throw new Error('PLAYWRIGHT_BABBEL_URL is required.');
-	}
+    if (!babbelURL) {
+        throw new Error('PLAYWRIGHT_BABBEL_URL is required.');
+    }
 
-	if (!babbelContext) {
-		babbelContext = await request.newContext();
-		const session = await babbelContext.post(`${babbelURL}/sessions`, {
-			data: BABBEL_ADMIN,
-		});
-		expect(session.status()).toBe(201);
-	}
+    if (!babbelContext) {
+        const context = await request.newContext();
+        const session = await context.post(`${babbelURL}/sessions`, {
+            data: BABBEL_ADMIN,
+        });
+        const body = await session.text();
+        try {
+            expect(session.status(), body).toBe(201);
+        } catch (error) {
+            await context.dispose();
+            throw error;
+        }
+        babbelContext = context;
+    }
 
-	return babbelContext.fetch(`${babbelURL}${path}`, options);
+    return babbelContext.fetch(`${babbelURL}${path}`, options);
 }

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -66,7 +66,17 @@ export async function savePost(page: Page): Promise<void> {
             button.form.requestSubmit(button);
         }),
     ]);
-    expect(response.status(), await response.text()).toBeLessThan(400);
+    const status = response.status();
+    let failureMessage = 'Post save failed.';
+    if (status >= 400) {
+        try {
+            failureMessage = await response.text();
+        } catch {
+            failureMessage =
+                'Post save failed and its response body is unavailable.';
+        }
+    }
+    expect(status, failureMessage).toBeLessThan(400);
     await expect(page).toHaveURL(/\/wp-admin\/post\.php\?post=\d+&action=edit/);
     await expect(page.locator('#publish')).toBeVisible();
 }

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -35,6 +35,21 @@ export const BABBEL_ADMIN = { username: 'admin', password: 'admin' };
 const babbelURL = process.env.PLAYWRIGHT_BABBEL_URL;
 let babbelContextPromise: Promise<APIRequestContext> | undefined;
 
+/**
+ * Assert a response succeeded, using its body as the failure message.
+ *
+ * Redirect responses have no readable body, so fall back to the label.
+ */
+async function expectResponseOk(
+    response: { status(): number; text(): Promise<string> },
+    label: string,
+): Promise<void> {
+    const status = response.status();
+    const detail =
+        status < 400 ? label : await response.text().catch(() => label);
+    expect(status, detail).toBeLessThan(400);
+}
+
 export async function login(page: Page): Promise<void> {
     await page.goto('/wp-login.php');
     const loginResponse = page.waitForResponse(
@@ -61,17 +76,7 @@ export async function login(page: Page): Promise<void> {
                 form.submit();
             }, WP_ADMIN),
     ]);
-    const status = response.status();
-    let failureMessage = 'Login failed.';
-    if (status >= 400) {
-        try {
-            failureMessage = await response.text();
-        } catch {
-            failureMessage =
-                'Login failed and its response body is unavailable.';
-        }
-    }
-    expect(status, failureMessage).toBeLessThan(400);
+    await expectResponseOk(response, 'Login failed.');
     await expect(page).toHaveURL(/\/wp-admin\//);
 }
 
@@ -98,17 +103,7 @@ export async function savePost(page: Page): Promise<void> {
             button.form.requestSubmit(button);
         }),
     ]);
-    const status = response.status();
-    let failureMessage = 'Post save failed.';
-    if (status >= 400) {
-        try {
-            failureMessage = await response.text();
-        } catch {
-            failureMessage =
-                'Post save failed and its response body is unavailable.';
-        }
-    }
-    expect(status, failureMessage).toBeLessThan(400);
+    await expectResponseOk(response, 'Post save failed.');
     await expect(page).toHaveURL(/\/wp-admin\/post\.php\?post=\d+&action=edit/);
     await expect(page.locator('#publish')).toBeVisible();
 }
@@ -129,8 +124,9 @@ export async function setBabbelEnabled(
     );
     await expect(checkbox).toBeVisible();
     await expect(checkbox).toBeEnabled();
-    // Chromium's click state can remain unchanged for this injected control,
-    // even when Playwright reports a completed forced click.
+    // A real click cannot drive this control: once the metabox re-renders for an
+    // already-synchronized post, the injected input never reaches Playwright's
+    // stable-and-visible state, so setChecked times out. Drive it directly instead.
     await checkbox.evaluate((input: HTMLInputElement, checked) => {
         input.checked = checked;
         input.dispatchEvent(new Event('input', { bubbles: true }));
@@ -164,21 +160,27 @@ export async function controlStory(
     return body.data;
 }
 
-export async function getBabbelStory(
-    storyID: string,
-): Promise<{ response: APIResponse; story?: BabbelStory }> {
+/**
+ * Read a story that must exist. Fails the test when it does not.
+ */
+export async function getBabbelStory(storyID: string): Promise<BabbelStory> {
+    const response = await babbelRequest(
+        `/stories/${encodeURIComponent(storyID)}`,
+    );
+    expect(response.status(), await response.text()).toBe(200);
+
+    return (await response.json()) as BabbelStory;
+}
+
+/**
+ * Read only the status code, for assertions about a story's absence.
+ */
+export async function babbelStoryStatus(storyID: string): Promise<number> {
     const response = await babbelRequest(
         `/stories/${encodeURIComponent(storyID)}`,
     );
 
-    if (response.status() !== 200) {
-        return { response };
-    }
-
-    return {
-        response,
-        story: (await response.json()) as BabbelStory,
-    };
+    return response.status();
 }
 
 export async function updateBabbelStory(
@@ -201,20 +203,11 @@ export async function countBabbelStoriesByTitle(
     const response = await babbelRequest(`/stories?${query.toString()}`);
     const rawBody = await response.text();
     expect(response.status(), rawBody).toBe(200);
-    const body = JSON.parse(rawBody) as {
-        data?: unknown;
-        limit?: unknown;
-        offset?: unknown;
-        total?: unknown;
-    };
-    expect(Array.isArray(body.data), rawBody).toBe(true);
-    const stories = body.data as BabbelStory[];
-    expect(body.limit, rawBody).toBe(100);
-    expect(body.offset, rawBody).toBe(0);
-    expect(body.total, rawBody).toBe(stories.length);
-    expect(stories.length, rawBody).toBeLessThan(100);
+    const { data } = JSON.parse(rawBody) as { data: BabbelStory[] };
+    // The filter is applied server-side, so a full page means results were truncated.
+    expect(data.length, rawBody).toBeLessThan(100);
 
-    return stories.filter((story) => story.title === title).length;
+    return data.filter((story) => story.title === title).length;
 }
 
 export async function disposeBabbelContext(): Promise<void> {
@@ -232,6 +225,9 @@ async function babbelRequest(
         throw new Error('PLAYWRIGHT_BABBEL_URL is required.');
     }
 
+    // Memoize the in-flight promise, not the resolved context: a single worker does
+    // not stop two concurrent callers from both entering this branch, which would
+    // leak a context and let one request run before the shared login completed.
     if (!babbelContextPromise) {
         babbelContextPromise = (async () => {
             const context = await request.newContext();
@@ -239,8 +235,7 @@ async function babbelRequest(
                 const session = await context.post(`${babbelURL}/sessions`, {
                     data: BABBEL_ADMIN,
                 });
-                const body = await session.text();
-                expect(session.status(), body).toBe(201);
+                expect(session.status(), await session.text()).toBe(201);
 
                 return context;
             } catch (error) {
@@ -250,6 +245,8 @@ async function babbelRequest(
         })();
     }
 
+    // Reset on failure so a later call retries the login instead of reusing a
+    // rejected promise, but only if nothing else replaced it in the meantime.
     const contextPromise = babbelContextPromise;
     let babbelContext: APIRequestContext;
     try {

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -37,9 +37,41 @@ let babbelContextPromise: Promise<APIRequestContext> | undefined;
 
 export async function login(page: Page): Promise<void> {
     await page.goto('/wp-login.php');
-    await page.getByLabel('Username or Email Address').fill(WP_ADMIN.username);
-    await page.getByLabel('Password', { exact: true }).fill(WP_ADMIN.password);
-    await page.getByRole('button', { name: 'Log In' }).click();
+    const loginResponse = page.waitForResponse(
+        (response) =>
+            response.request().method() === 'POST' &&
+            new URL(response.url()).pathname === '/wp-login.php',
+    );
+    const [response] = await Promise.all([
+        loginResponse,
+        page
+            .locator('#loginform')
+            .evaluate((form: HTMLFormElement, credentials) => {
+                const username = form.elements.namedItem('log');
+                const password = form.elements.namedItem('pwd');
+                if (
+                    !(username instanceof HTMLInputElement) ||
+                    !(password instanceof HTMLInputElement)
+                ) {
+                    throw new Error('The login fields are unavailable.');
+                }
+
+                username.value = credentials.username;
+                password.value = credentials.password;
+                form.submit();
+            }, WP_ADMIN),
+    ]);
+    const status = response.status();
+    let failureMessage = 'Login failed.';
+    if (status >= 400) {
+        try {
+            failureMessage = await response.text();
+        } catch {
+            failureMessage =
+                'Login failed and its response body is unavailable.';
+        }
+    }
+    expect(status, failureMessage).toBeLessThan(400);
     await expect(page).toHaveURL(/\/wp-admin\//);
 }
 
@@ -97,9 +129,13 @@ export async function setBabbelEnabled(
     );
     await expect(checkbox).toBeVisible();
     await expect(checkbox).toBeEnabled();
-    // After an edit-screen reload, CI traces show that Playwright's stability
-    // check never settles for this injected control.
-    await checkbox.setChecked(enabled, { force: true });
+    // Chromium's click state can remain unchanged for this injected control,
+    // even when Playwright reports a completed forced click.
+    await checkbox.evaluate((input: HTMLInputElement, checked) => {
+        input.checked = checked;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+    }, enabled);
     await expect(checkbox).toBeChecked({ checked: enabled });
 }
 

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -96,7 +96,11 @@ export async function setBabbelEnabled(
         '.knabbel-radionieuws-injected #knabbel_send_to_babbel',
     );
     await expect(checkbox).toBeVisible();
-    await checkbox.setChecked(enabled);
+    await expect(checkbox).toBeEnabled();
+    // After an edit-screen reload, CI traces show that Playwright's stability
+    // check never settles for this injected control.
+    await checkbox.setChecked(enabled, { force: true });
+    await expect(checkbox).toBeChecked({ checked: enabled });
 }
 
 export async function controlStory(

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -33,7 +33,7 @@ export const WP_ADMIN = { username: 'admin', password: 'e2e-admin-password' };
 export const BABBEL_ADMIN = { username: 'admin', password: 'admin' };
 
 const babbelURL = process.env.PLAYWRIGHT_BABBEL_URL;
-let babbelContext: APIRequestContext | undefined;
+let babbelContextPromise: Promise<APIRequestContext> | undefined;
 
 export async function login(page: Page): Promise<void> {
     await page.goto('/wp-login.php');
@@ -168,8 +168,10 @@ export async function countBabbelStoriesByTitle(
 }
 
 export async function disposeBabbelContext(): Promise<void> {
-    await babbelContext?.dispose();
-    babbelContext = undefined;
+    const contextPromise = babbelContextPromise;
+    babbelContextPromise = undefined;
+    const context = await contextPromise?.catch(() => undefined);
+    await context?.dispose();
 }
 
 async function babbelRequest(
@@ -180,19 +182,33 @@ async function babbelRequest(
         throw new Error('PLAYWRIGHT_BABBEL_URL is required.');
     }
 
-    if (!babbelContext) {
-        const context = await request.newContext();
-        const session = await context.post(`${babbelURL}/sessions`, {
-            data: BABBEL_ADMIN,
-        });
-        const body = await session.text();
-        try {
-            expect(session.status(), body).toBe(201);
-        } catch (error) {
-            await context.dispose();
-            throw error;
+    if (!babbelContextPromise) {
+        babbelContextPromise = (async () => {
+            const context = await request.newContext();
+            try {
+                const session = await context.post(`${babbelURL}/sessions`, {
+                    data: BABBEL_ADMIN,
+                });
+                const body = await session.text();
+                expect(session.status(), body).toBe(201);
+
+                return context;
+            } catch (error) {
+                await context.dispose();
+                throw error;
+            }
+        })();
+    }
+
+    const contextPromise = babbelContextPromise;
+    let babbelContext: APIRequestContext;
+    try {
+        babbelContext = await contextPromise;
+    } catch (error) {
+        if (babbelContextPromise === contextPromise) {
+            babbelContextPromise = undefined;
         }
-        babbelContext = context;
+        throw error;
     }
 
     return babbelContext.fetch(`${babbelURL}${path}`, options);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["playwright.config.ts", "tests/playwright/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- add six Playwright flows for WordPress settings, publishing, editing, scheduling, trashing, and Babbel synchronization
- run Chromium against the isolated Docker WordPress and Babbel services before the existing backend regression suite
- install Playwright in CI and upload browser reports and failure artifacts

## Test plan

- BABBEL_PATH=../zwfm-babbel tests/e2e/run.sh (6 browser tests and 11 backend scenarios / 127 assertions)
- vendor/bin/phpcs
- vendor/bin/phpstan analyse
- npm run lint
- npx playwright test --list
- shellcheck tests/e2e/run.sh
- docker compose config --quiet

## Dependency

This is a stacked PR on top of #32 so the review stays limited to the browser E2E layer. After #32 merges, this PR can be retargeted to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added serialized Playwright E2E coverage for WordPress editor ↔ Babbel integration, including deterministic authenticated setup.
* **Documentation**
  * Expanded local E2E run prerequisites and clarified scenario execution in the E2E catalog.
* **CI / Quality**
  * Improved CI triggers and E2E job reliability: better Playwright/Chromium caching, richer artifact uploads, stricter Playwright config, and automatic WordPress debug-log cleanliness checks.
  * Enhanced E2E orchestration for scheduled and lifecycle actions, plus additional admin/UI/browser error assertions.
* **Chores**
  * Added TypeScript/Playwright tooling (lint/typecheck/format), updated ignore rules, and adjusted related workflow/lint triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->