### PR TITLE
refactor(admin): remove ACF metabox injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Publishes selected WordPress posts as radio stories in the [Babbel API](https://
 
 ## What it does
 
-- moves the native **Radionieuws** metabox control into the configured ACF field group
+- adds a native **Radionieuws** metabox to the post editor
 - generates provider-independent speech text through the WordPress AI Client
 - creates, updates, deletes, and restores the matching Babbel story
 - learns from editor-corrected Babbel text through nightly few-shot synchronization
@@ -14,7 +14,6 @@ Publishes selected WordPress posts as radio stories in the [Babbel API](https://
 
 - WordPress 7.0+
 - PHP 8.3 or 8.4
-- [Advanced Custom Fields](https://www.advancedcustomfields.com/) (ACF)
 - A compatible AI provider configured under **Settings > Connectors**
 - A running instance of the [Babbel API](https://github.com/oszuidwest/zwfm-babbel)
 

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -397,30 +397,6 @@
 }
 
 /* ==========================================================================
-   ACF Integration - radionieuws metabox injection
-   ========================================================================== */
-
-/* Hide the original metabox when injected into ACF */
-#knabbel-radionieuws {
-    display: none !important;
-}
-
-/* Force first two ACF fields to 33.33% width and stay on same row */
-#acf-group_5f21a05a18b57 .acf-fields > .acf-field:first-child,
-#acf-group_5f21a05a18b57 .acf-fields > .acf-field:nth-child(2) {
-    width: 33.33% !important;
-    float: left !important;
-}
-
-/* Style our injected radionieuws field to match */
-.knabbel-radionieuws-injected {
-    width: 33.33% !important;
-    min-height: 81px !important;
-    float: left !important;
-    box-sizing: border-box !important;
-}
-
-/* ==========================================================================
    Settings Page - Card-based Layout
    ========================================================================== */
 

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,7 +1,7 @@
 /**
  * Knabbel WP Admin JavaScript
  *
- * Handles API testing, weekday toggles, and ACF integration.
+ * Handles API testing and weekday toggles.
  */
 
 (() => {
@@ -79,73 +79,6 @@
     }
 
     /**
-     * ACF Integration - Inject radionieuws checkbox into ACF field group
-     */
-    function initAcfIntegration() {
-        const radionieuwsBox = document.getElementById('knabbel-radionieuws');
-        if (!radionieuwsBox) return;
-
-        // Wait for ACF to load
-        setTimeout(() => {
-            const acfBox = document.querySelector(
-                '#acf-group_5f21a05a18b57 .acf-fields',
-            );
-            const inside = radionieuwsBox.querySelector('.inside');
-
-            if (
-                !acfBox ||
-                !inside ||
-                document.querySelector('.knabbel-radionieuws-injected')
-            ) {
-                return;
-            }
-
-            // Build wrapper matching ACF's own field structure using DOM methods.
-            // The first ACF field ("Toon in kabelkrant") is 50% wide,
-            // leaving 50% empty space for our checkbox on the same row.
-            const wrapper = document.createElement('div');
-            wrapper.className =
-                'acf-field acf-field-true-false knabbel-radionieuws-injected -r0';
-            wrapper.dataset.width = '50';
-            wrapper.style.width = '50%';
-            wrapper.style.minHeight = '0';
-
-            const acfLabel = document.createElement('div');
-            acfLabel.className = 'acf-label';
-            const labelEl = document.createElement('label');
-            labelEl.textContent = 'Radionieuws';
-            acfLabel.appendChild(labelEl);
-
-            const acfInput = document.createElement('div');
-            acfInput.className = 'acf-input';
-            const trueFalse = document.createElement('div');
-            trueFalse.className = 'acf-true-false';
-            acfInput.appendChild(trueFalse);
-
-            wrapper.appendChild(acfLabel);
-            wrapper.appendChild(acfInput);
-
-            // Move (not clone) checkbox and hidden input to ACF area.
-            // This ensures only one checkbox exists in the form.
-            const checkbox = inside.querySelector('input[type="checkbox"]');
-            const hidden = inside.querySelector('input[type="hidden"]');
-
-            if (checkbox) {
-                const inputLabel = document.createElement('label');
-                if (hidden) inputLabel.appendChild(hidden);
-                inputLabel.appendChild(checkbox);
-                trueFalse.appendChild(inputLabel);
-            }
-
-            // Insert after the first field to fill its empty 50% space.
-            const firstField = acfBox.querySelector('.acf-field:first-child');
-            if (firstField) {
-                firstField.insertAdjacentElement('afterend', wrapper);
-            }
-        }, 200);
-    }
-
-    /**
      * Initialize on DOM ready
      */
     if (document.readyState === 'loading') {
@@ -157,6 +90,5 @@
     function init() {
         initApiTest();
         initWeekdayToggles();
-        initAcfIntegration();
     }
 })();

--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -49,14 +49,6 @@ function metabox_enqueue_assets( string $hook ): void {
 		array(),
 		KNABBEL_VERSION
 	);
-
-	wp_enqueue_script(
-		'zw-knabbel-wp-admin',
-		KNABBEL_PLUGIN_URL . 'assets/admin.js',
-		array(),
-		KNABBEL_VERSION,
-		true
-	);
 }
 
 /**

--- a/tests/e2e/mu-plugins/knabbel-e2e-control.php
+++ b/tests/e2e/mu-plugins/knabbel-e2e-control.php
@@ -24,26 +24,6 @@ add_filter(
 	2
 );
 
-add_action(
-	'add_meta_boxes_post',
-	static function (): void {
-		add_meta_box(
-			// This exact ID is load-bearing: assets/admin.js and assets/admin.css
-			// target #acf-group_5f21a05a18b57 (the production ACF group) to inject
-			// the radionieuws checkbox, and the original metabox is hidden
-			// unconditionally. Without a box of this ID the checkbox is unusable.
-			'acf-group_5f21a05a18b57',
-			'Knabbel E2E article fields',
-			static function (): void {
-				echo '<div class="acf-fields"><div class="acf-field"></div></div>';
-			},
-			'post',
-			'normal',
-			'high'
-		);
-	}
-);
-
 /**
  * Run due Action Scheduler actions for a hook and fail loudly on errors.
  *

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -117,18 +117,11 @@ export async function setBabbelEnabled(
     enabled: boolean,
 ): Promise<void> {
     const checkbox = page.locator(
-        '.knabbel-radionieuws-injected #knabbel_send_to_babbel',
+        '#knabbel-radionieuws #knabbel_send_to_babbel',
     );
     await expect(checkbox).toBeVisible();
     await expect(checkbox).toBeEnabled();
-    // A real click cannot drive this control: once the metabox re-renders for an
-    // already-synchronized post, the injected input never reaches Playwright's
-    // stable-and-visible state, so setChecked times out. Drive it directly instead.
-    await checkbox.evaluate((input: HTMLInputElement, checked) => {
-        input.checked = checked;
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-        input.dispatchEvent(new Event('change', { bubbles: true }));
-    }, enabled);
+    await checkbox.setChecked(enabled);
     await expect(checkbox).toBeChecked({ checked: enabled });
 }
 


### PR DESCRIPTION
## Summary

- keep the Radionieuws control in its native WordPress metabox
- remove the hard-coded ACF DOM injection, hiding CSS, and post-editor script enqueue
- remove the ACF requirement and update the browser test fixture and selector

## Testing

- npm run lint
- vendor/bin/phpcs
- vendor/bin/phpstan analyse includes/admin/metabox.php --memory-limit=2G --no-progress
- git diff --check

The full PHPStan run still reports seven pre-existing missing WordPress AI Client symbols in includes/ai-handler.php.

## Screenshots

Not included; the isolated browser stack requires the external Babbel checkout. The updated Playwright coverage now targets the visible native metabox directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Radionieuws is now managed through a native metabox in the editor.
  - The plugin no longer requires ACF for Radionieuws settings.

- **Improvements**
  - Simplified the editor experience by removing the previous ACF-based integration.
  - Updated the Radionieuws control behavior for more reliable checkbox interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->