### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/languages/zw-knabbel-wp-nl_NL.po
+++ b/languages/zw-knabbel-wp-nl_NL.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: ZuidWest Knabbel 0.4.0\n"
+"Project-Id-Version: ZuidWest Knabbel 0.5.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
 "POT-Creation-Date: 2026-07-26T21:56:40+00:00\n"
 "PO-Revision-Date: 2026-07-26T20:34:04+00:00\n"

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: ZuidWest Knabbel 0.4.0\n"
+"Project-Id-Version: ZuidWest Knabbel 0.5.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -3,7 +3,7 @@
  * Plugin Name: ZuidWest Knabbel
  * Plugin URI: https://github.com/oszuidwest/zw-knabbel-wp
  * Description: WordPress plugin om berichten naar de Babbel API te sturen voor het radionieuws. Gebruikt de WordPress AI Client voor AI-gegenereerde content.
- * Version: 0.4.0
+ * Version: 0.5.0
  * Requires at least: 7.0
  * Requires PHP: 8.3
  * Author: Streekomroep ZuidWest


### PR DESCRIPTION
## Beschrijving

Verhoogt de pluginversie van 0.4.0 naar 0.5.0 op basis van de features en fixes sinds de laatste release. Werkt ook de versie in de PO- en POT-metadata bij.

## Testen

- vendor/bin/phpcs
- npm run lint
- PHP-syntaxcontrole
- gettext-validatie
- vendor/bin/phpstan analyse --memory-limit=512M (rapporteert 7 reeds bestaande ontbrekende WordPress AI Client-symbolen)