### PR TITLE
feat(admin): move Radio News control to publish box

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Publishes selected WordPress posts as radio stories in the [Babbel API](https://
 
 ## What it does
 
-- adds a native **Radionieuws** metabox to the post editor
+- adds a native **Radionieuws** control to the Publish box in the post editor
 - generates provider-independent speech text through the WordPress AI Client
 - creates, updates, deletes, and restores the matching Babbel story
 - learns from editor-corrected Babbel text through nightly few-shot synchronization

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Publishes selected WordPress posts as radio stories in the [Babbel API](https://
 
 ## What it does
 
-- adds a native **Radionieuws** control to the Publish box in the post editor
+- adds a native **Radionieuws** control to the Publish box in the Classic Editor
 - generates provider-independent speech text through the WordPress AI Client
 - creates, updates, deletes, and restores the matching Babbel story
 - learns from editor-corrected Babbel text through nightly few-shot synchronization
@@ -14,6 +14,7 @@ Publishes selected WordPress posts as radio stories in the [Babbel API](https://
 
 - WordPress 7.0+
 - PHP 8.3 or 8.4
+- The [Classic Editor](https://wordpress.org/plugins/classic-editor/) plugin, installed and activated; the block editor is not supported
 - A compatible AI provider configured under **Settings > Connectors**
 - A running instance of the [Babbel API](https://github.com/oszuidwest/zwfm-babbel)
 

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -86,6 +86,53 @@
 }
 
 /* ==========================================================================
+   Publish box - Radionieuws control
+   ========================================================================== */
+
+.misc-pub-knabbel > .dashicons {
+    color: #8c8f94;
+}
+
+#knabbel_send_to_babbel {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.knabbel-submitbox-toggle {
+    color: var(--wp-admin-theme-color);
+    cursor: pointer;
+    font-weight: 600;
+    text-decoration: underline;
+}
+
+.knabbel-submitbox-toggle:hover {
+    color: var(--wp-admin-theme-color-darker-20);
+}
+
+.knabbel-submitbox-toggle-enabled,
+#knabbel_send_to_babbel:checked
+    + .knabbel-submitbox-toggle
+    .knabbel-submitbox-toggle-disabled {
+    display: none;
+}
+
+#knabbel_send_to_babbel:checked
+    + .knabbel-submitbox-toggle
+    .knabbel-submitbox-toggle-enabled {
+    display: inline;
+}
+
+#knabbel_send_to_babbel:focus-visible + .knabbel-submitbox-toggle {
+    border-radius: 2px;
+    color: var(--wp-admin-theme-color);
+    box-shadow: 0 0 0 var(--wp-admin-border-width-focus, 1.5px)
+        var(--wp-admin-theme-color);
+    outline: 1px solid transparent;
+}
+
+/* ==========================================================================
    Toggle Switch - settings page
    ========================================================================== */
 

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -95,9 +95,15 @@
 
 #knabbel_send_to_babbel {
     position: absolute;
-    opacity: 0;
-    width: 0;
-    height: 0;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    border: 0;
+    white-space: nowrap;
 }
 
 .knabbel-submitbox-toggle {

--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 0.1.0
  */
 function metabox_init(): void {
-	add_action( 'add_meta_boxes', __NAMESPACE__ . '\\metabox_add' );
+	add_action( 'post_submitbox_misc_actions', __NAMESPACE__ . '\\submitbox_render' );
 	add_action( 'add_meta_boxes', __NAMESPACE__ . '\\metabox_add_status' );
 	add_action( 'save_post', __NAMESPACE__ . '\\metabox_save' );
 	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\metabox_enqueue_assets' );
@@ -52,22 +52,6 @@ function metabox_enqueue_assets( string $hook ): void {
 }
 
 /**
- * Adds the Radionieuws metabox to the post edit screen.
- *
- * @since 0.1.0
- */
-function metabox_add(): void {
-	add_meta_box(
-		'knabbel-radionieuws',
-		__( 'Radio News', 'zw-knabbel-wp' ),
-		__NAMESPACE__ . '\\metabox_render',
-		'post',
-		'side',
-		'high'
-	);
-}
-
-/**
  * Adds the per-post status metabox when Debug Mode is enabled.
  *
  * @since 0.1.0
@@ -88,32 +72,46 @@ function metabox_add_status(): void {
 }
 
 /**
- * Displays the Radionieuws metabox content.
+ * Displays the Radionieuws control in the Publish metabox.
  *
  * @since 0.1.0
  *
  * @param \WP_Post $post The current post object.
  */
-function metabox_render( \WP_Post $post ): void {
-		wp_nonce_field( 'knabbel_metabox_nonce', 'knabbel_nonce' );
-
-		$send_to_babbel = get_post_meta( $post->ID, '_zw_knabbel_send_to_babbel', true );
-		$state          = get_story_state( $post->ID );
-		$sync_error     = get_story_sync_error( $state );
-
-		echo '<p>';
-		echo '<label for="knabbel_send_to_babbel">';
-		echo '<input type="checkbox" id="knabbel_send_to_babbel" name="knabbel_send_to_babbel" value="1" ' . checked( 1, $send_to_babbel, false ) . ' />';
-		echo ' ' . esc_html__( 'Radio News', 'zw-knabbel-wp' );
-		echo '</label>';
-		echo '</p>';
-
-	if ( is_story_sync_error_renderable( $sync_error ) && null !== $sync_error ) {
-		echo '<div class="knabbel-sync-warning" role="alert">';
-		echo '<strong>' . esc_html__( 'Babbel sync warning', 'zw-knabbel-wp' ) . '</strong>';
-		echo '<div>' . esc_html( $sync_error['message'] ) . '</div>';
-		echo '</div>';
+function submitbox_render( \WP_Post $post ): void {
+	if ( 'post' !== $post->post_type ) {
+		return;
 	}
+
+	$send_to_babbel = (bool) get_post_meta( $post->ID, '_zw_knabbel_send_to_babbel', true );
+	$state          = get_story_state( $post->ID );
+	$sync_error     = get_story_sync_error( $state );
+
+	wp_nonce_field( 'knabbel_metabox_nonce', 'knabbel_nonce' );
+	?>
+	<div class="misc-pub-section misc-pub-knabbel">
+		<span class="dashicons dashicons-microphone" aria-hidden="true"></span>
+		<label for="knabbel_send_to_babbel"><?php esc_html_e( 'Radio News', 'zw-knabbel-wp' ); ?>:</label>
+		<input
+			type="checkbox"
+			id="knabbel_send_to_babbel"
+			name="knabbel_send_to_babbel"
+			value="1"
+			<?php checked( $send_to_babbel ); ?>
+		/>
+		<label class="knabbel-submitbox-toggle" for="knabbel_send_to_babbel">
+			<span class="knabbel-submitbox-toggle-enabled" aria-hidden="true"><?php esc_html_e( 'Yes', 'zw-knabbel-wp' ); ?></span>
+			<span class="knabbel-submitbox-toggle-disabled" aria-hidden="true"><?php esc_html_e( 'No', 'zw-knabbel-wp' ); ?></span>
+		</label>
+
+		<?php if ( is_story_sync_error_renderable( $sync_error ) ) : ?>
+			<div class="knabbel-sync-warning" role="alert">
+				<strong><?php esc_html_e( 'Babbel sync warning', 'zw-knabbel-wp' ); ?></strong>
+				<div><?php echo esc_html( $sync_error['message'] ); ?></div>
+			</div>
+		<?php endif; ?>
+	</div>
+	<?php
 }
 
 /**
@@ -173,7 +171,7 @@ function metabox_render_status( \WP_Post $post ): void {
 				?>
 			</li>
 			<?php endif; ?>
-			<?php if ( is_story_sync_error_renderable( $sync_error ) && null !== $sync_error ) : ?>
+			<?php if ( is_story_sync_error_renderable( $sync_error ) ) : ?>
 			<li>
 				<strong><?php esc_html_e( 'Last sync error', 'zw-knabbel-wp' ); ?>:</strong>
 				<div class="knabbel-sync-warning">

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -773,7 +773,7 @@ function render_articles_overview(): void {
 					<td class="muted">—</td>
 				</tr>
 				<?php endif; ?>
-				<?php if ( is_story_sync_error_renderable( $sync_error ) && null !== $sync_error ) : ?>
+				<?php if ( is_story_sync_error_renderable( $sync_error ) ) : ?>
 				<tr>
 					<td class="label-cell"><?php esc_html_e( 'Last sync error', 'zw-knabbel-wp' ); ?></td>
 					<td class="error-message">

--- a/languages/zw-knabbel-wp-nl_NL.po
+++ b/languages/zw-knabbel-wp-nl_NL.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ZuidWest Knabbel 0.5.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
-"POT-Creation-Date: 2026-07-26T21:56:40+00:00\n"
-"PO-Revision-Date: 2026-07-26T20:34:04+00:00\n"
+"POT-Creation-Date: 2026-08-11T14:16:07+00:00\n"
+"PO-Revision-Date: 2026-08-11T14:16:07+00:00\n"
 "Last-Translator: Remon Mens\n"
 "Language-Team: Dutch\n"
 "Language: nl_NL\n"
@@ -42,68 +42,76 @@ msgstr ""
 msgid "https://www.zuidwesttv.nl"
 msgstr ""
 
-#: includes/admin/metabox.php:70 includes/admin/metabox.php:115
-msgid "Radio News"
-msgstr "Radionieuws"
-
-#: includes/admin/metabox.php:90
+#: includes/admin/metabox.php:66
 msgid "Knabbel Status"
 msgstr "Knabbel Status"
 
-#: includes/admin/metabox.php:121
+#: includes/admin/metabox.php:94
+msgid "Radio News"
+msgstr "Radionieuws"
+
+#: includes/admin/metabox.php:103
+msgid "Yes"
+msgstr "Ja"
+
+#: includes/admin/metabox.php:104
+msgid "No"
+msgstr "Nee"
+
+#: includes/admin/metabox.php:109
 msgid "Babbel sync warning"
 msgstr "Waarschuwing bij Babbel-synchronisatie"
 
-#: includes/admin/metabox.php:145 includes/admin/settings.php:561
+#: includes/admin/metabox.php:135 includes/admin/settings.php:561
 #: includes/admin/settings.php:740
 msgid "Status"
 msgstr "Status"
 
-#: includes/admin/metabox.php:149 includes/admin/settings.php:684
+#: includes/admin/metabox.php:139 includes/admin/settings.php:684
 msgid "Scheduled"
 msgstr "Ingepland"
 
-#: includes/admin/metabox.php:150 includes/admin/settings.php:685
+#: includes/admin/metabox.php:140 includes/admin/settings.php:685
 msgid "Processing"
 msgstr "Bezig"
 
-#: includes/admin/metabox.php:151 includes/admin/settings.php:686
+#: includes/admin/metabox.php:141 includes/admin/settings.php:686
 msgid "Sent"
 msgstr "Verzonden"
 
-#: includes/admin/metabox.php:152 includes/admin/settings.php:687
+#: includes/admin/metabox.php:142 includes/admin/settings.php:687
 msgid "Error"
 msgstr "Fout"
 
-#: includes/admin/metabox.php:153
+#: includes/admin/metabox.php:143
 msgid "Deleted"
 msgstr "Verwijderd"
 
-#: includes/admin/metabox.php:155
+#: includes/admin/metabox.php:145
 msgid "—"
 msgstr "—"
 
-#: includes/admin/metabox.php:161
+#: includes/admin/metabox.php:151
 msgid "Last status change:"
 msgstr "Laatste statuswijziging:"
 
-#: includes/admin/metabox.php:171
+#: includes/admin/metabox.php:161
 msgid "Story ID"
 msgstr "Verhaal-ID"
 
-#: includes/admin/metabox.php:177
+#: includes/admin/metabox.php:167
 msgid "Scheduled:"
 msgstr "Ingepland:"
 
-#: includes/admin/metabox.php:186 includes/admin/settings.php:778
+#: includes/admin/metabox.php:176 includes/admin/settings.php:778
 msgid "Last sync error"
 msgstr "Laatste synchronisatiefout"
 
-#: includes/admin/metabox.php:192 includes/admin/settings.php:783
+#: includes/admin/metabox.php:182 includes/admin/settings.php:783
 msgid "Operation"
 msgstr "Bewerking"
 
-#: includes/admin/metabox.php:210 includes/admin/settings.php:297
+#: includes/admin/metabox.php:200 includes/admin/settings.php:297
 #: includes/admin/settings.php:762 includes/admin/settings.php:767
 msgid "Message"
 msgstr "Bericht"
@@ -322,7 +330,7 @@ msgstr "Laatste statuswijziging"
 msgid "Babbel ID"
 msgstr "Babbel ID"
 
-#: includes/admin/settings.php:768 zw-knabbel-wp.php:691
+#: includes/admin/settings.php:768 zw-knabbel-wp.php:694
 msgid "Story is being processed..."
 msgstr "Verhaal wordt verwerkt..."
 
@@ -378,7 +386,7 @@ msgstr "API-fout"
 msgid "No story ID received from API"
 msgstr "Geen verhaal-ID ontvangen van API"
 
-#: includes/babbel-api.php:325 zw-knabbel-wp.php:746
+#: includes/babbel-api.php:325 zw-knabbel-wp.php:749
 msgid "Story created successfully"
 msgstr "Verhaal succesvol aangemaakt"
 
@@ -436,58 +444,58 @@ msgstr "Babbel API basis-URL niet geconfigureerd"
 msgid "API error: HTTP %d"
 msgstr "API-fout: HTTP %d"
 
-#: includes/post-hooks.php:210
+#: includes/post-hooks.php:113
 msgid "Story deleted from Babbel"
 msgstr "Verhaal verwijderd uit Babbel"
 
-#: includes/post-hooks.php:300
-msgid "Story updated (post published)"
-msgstr "Verhaal bijgewerkt (bericht gepubliceerd)"
-
-#: includes/post-hooks.php:335
-msgid "Story updated in Babbel"
-msgstr "Verhaal bijgewerkt in Babbel"
-
-#: includes/post-hooks.php:354
-msgid "Story deleted (post unscheduled)"
-msgstr "Verhaal verwijderd (bericht niet meer ingepland)"
-
-#: includes/post-hooks.php:385
+#: includes/post-hooks.php:116
 msgid "Story deleted (post trashed)"
 msgstr "Verhaal verwijderd (bericht in prullenbak)"
 
-#: includes/post-hooks.php:450 includes/post-hooks.php:470
+#: includes/post-hooks.php:119
+msgid "Story deleted (post unscheduled)"
+msgstr "Verhaal verwijderd (bericht niet meer ingepland)"
+
+#: includes/post-hooks.php:162
+msgid "Story updated (post published)"
+msgstr "Verhaal bijgewerkt (bericht gepubliceerd)"
+
+#: includes/post-hooks.php:175
+msgid "Story updated in Babbel"
+msgstr "Verhaal bijgewerkt in Babbel"
+
+#: includes/post-hooks.php:214 includes/post-hooks.php:234
 msgid "Story restored in Babbel"
 msgstr "Verhaal hersteld in Babbel"
 
-#: includes/post-hooks.php:640
+#: includes/post-hooks.php:404
 msgid "Processing already scheduled"
 msgstr "Verwerking al ingepland"
 
-#: includes/post-hooks.php:659
+#: includes/post-hooks.php:423
 msgid "Processing scheduled"
 msgstr "Verwerking ingepland"
 
-#: includes/post-hooks.php:667
+#: includes/post-hooks.php:431
 msgid "Could not schedule action"
 msgstr "Kon actie niet inplannen"
 
-#: zw-knabbel-wp.php:616
+#: zw-knabbel-wp.php:619
 msgid "Insufficient permissions"
 msgstr "Onvoldoende rechten"
 
-#: zw-knabbel-wp.php:655
+#: zw-knabbel-wp.php:658
 msgid "Already sent — skipping"
 msgstr "Al verzonden — wordt overgeslagen"
 
-#: zw-knabbel-wp.php:667
+#: zw-knabbel-wp.php:670
 msgid "Post not found"
 msgstr "Bericht niet gevonden"
 
-#: zw-knabbel-wp.php:680
+#: zw-knabbel-wp.php:683
 msgid "Send to Babbel is disabled for this post"
 msgstr "Verzenden naar Babbel is uitgeschakeld voor dit bericht"
 
-#: zw-knabbel-wp.php:707
+#: zw-knabbel-wp.php:710
 msgid "Could not generate speech text"
 msgstr "Kon spreektekst niet genereren"

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-26T21:56:40+00:00\n"
+"POT-Creation-Date: 2026-08-11T14:16:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zw-knabbel-wp\n"
@@ -41,76 +41,83 @@ msgstr ""
 msgid "https://www.zuidwesttv.nl"
 msgstr ""
 
-#: includes/admin/metabox.php:70
-#: includes/admin/metabox.php:115
-msgid "Radio News"
-msgstr ""
-
-#: includes/admin/metabox.php:90
+#: includes/admin/metabox.php:66
 msgid "Knabbel Status"
 msgstr ""
 
-#: includes/admin/metabox.php:121
+#: includes/admin/metabox.php:94
+msgid "Radio News"
+msgstr ""
+
+#: includes/admin/metabox.php:103
+msgid "Yes"
+msgstr ""
+
+#: includes/admin/metabox.php:104
+msgid "No"
+msgstr ""
+
+#: includes/admin/metabox.php:109
 msgid "Babbel sync warning"
 msgstr ""
 
-#: includes/admin/metabox.php:145
+#: includes/admin/metabox.php:135
 #: includes/admin/settings.php:561
 #: includes/admin/settings.php:740
 msgid "Status"
 msgstr ""
 
-#: includes/admin/metabox.php:149
+#: includes/admin/metabox.php:139
 #: includes/admin/settings.php:684
 msgid "Scheduled"
 msgstr ""
 
-#: includes/admin/metabox.php:150
+#: includes/admin/metabox.php:140
 #: includes/admin/settings.php:685
 msgid "Processing"
 msgstr ""
 
-#: includes/admin/metabox.php:151
+#: includes/admin/metabox.php:141
 #: includes/admin/settings.php:686
 msgid "Sent"
 msgstr ""
 
-#: includes/admin/metabox.php:152
+#: includes/admin/metabox.php:142
 #: includes/admin/settings.php:687
 msgid "Error"
 msgstr ""
 
-#: includes/admin/metabox.php:153
+#: includes/admin/metabox.php:143
 msgid "Deleted"
 msgstr ""
 
-#: includes/admin/metabox.php:155
+#: includes/admin/metabox.php:145
 msgid "—"
 msgstr ""
 
-#: includes/admin/metabox.php:161
+#: includes/admin/metabox.php:151
 msgid "Last status change:"
 msgstr ""
 
-#: includes/admin/metabox.php:171
+#: includes/admin/metabox.php:161
 msgid "Story ID"
 msgstr ""
 
-#: includes/admin/metabox.php:177
+#: includes/admin/metabox.php:167
 msgid "Scheduled:"
 msgstr ""
 
-#: includes/admin/metabox.php:186
+#: includes/admin/metabox.php:176
 #: includes/admin/settings.php:778
 msgid "Last sync error"
 msgstr ""
 
-#: includes/admin/metabox.php:192
+#: includes/admin/metabox.php:182
 #: includes/admin/settings.php:783
 msgid "Operation"
 msgstr ""
 
-#: includes/admin/metabox.php:210
+#: includes/admin/metabox.php:200
 #: includes/admin/settings.php:297
 #: includes/admin/settings.php:762
 #: includes/admin/settings.php:767
@@ -320,7 +327,7 @@ msgid "Babbel ID"
 msgstr ""
 
 #: includes/admin/settings.php:768
-#: zw-knabbel-wp.php:691
+#: zw-knabbel-wp.php:694
 msgid "Story is being processed..."
 msgstr ""
 
@@ -385,7 +392,7 @@ msgid "No story ID received from API"
 msgstr ""
 
 #: includes/babbel-api.php:325
-#: zw-knabbel-wp.php:746
+#: zw-knabbel-wp.php:749
 msgid "Story created successfully"
 msgstr ""
 
@@ -445,59 +452,59 @@ msgstr ""
 msgid "API error: HTTP %d"
 msgstr ""
 
-#: includes/post-hooks.php:210
+#: includes/post-hooks.php:113
 msgid "Story deleted from Babbel"
 msgstr ""
 
-#: includes/post-hooks.php:300
-msgid "Story updated (post published)"
-msgstr ""
-
-#: includes/post-hooks.php:335
-msgid "Story updated in Babbel"
-msgstr ""
-
-#: includes/post-hooks.php:354
-msgid "Story deleted (post unscheduled)"
-msgstr ""
-
-#: includes/post-hooks.php:385
+#: includes/post-hooks.php:116
 msgid "Story deleted (post trashed)"
 msgstr ""
 
-#: includes/post-hooks.php:450
-#: includes/post-hooks.php:470
+#: includes/post-hooks.php:119
+msgid "Story deleted (post unscheduled)"
+msgstr ""
+
+#: includes/post-hooks.php:162
+msgid "Story updated (post published)"
+msgstr ""
+
+#: includes/post-hooks.php:175
+msgid "Story updated in Babbel"
+msgstr ""
+
+#: includes/post-hooks.php:214
+#: includes/post-hooks.php:234
 msgid "Story restored in Babbel"
 msgstr ""
 
-#: includes/post-hooks.php:640
+#: includes/post-hooks.php:404
 msgid "Processing already scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:659
+#: includes/post-hooks.php:423
 msgid "Processing scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:667
+#: includes/post-hooks.php:431
 msgid "Could not schedule action"
 msgstr ""
 
-#: zw-knabbel-wp.php:616
+#: zw-knabbel-wp.php:619
 msgid "Insufficient permissions"
 msgstr ""
 
-#: zw-knabbel-wp.php:655
+#: zw-knabbel-wp.php:658
 msgid "Already sent — skipping"
 msgstr ""
 
-#: zw-knabbel-wp.php:667
+#: zw-knabbel-wp.php:670
 msgid "Post not found"
 msgstr ""
 
-#: zw-knabbel-wp.php:680
+#: zw-knabbel-wp.php:683
 msgid "Send to Babbel is disabled for this post"
 msgstr ""
 
-#: zw-knabbel-wp.php:707
+#: zw-knabbel-wp.php:710
 msgid "Could not generate speech text"
 msgstr ""

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -132,6 +132,7 @@ wp core install \
 	--skip-email
 wp option update timezone_string Europe/Amsterdam
 wp plugin install ai-provider-for-openai --version=1.0.3 --activate
+wp plugin install classic-editor --version=1.7.0 --activate
 wp plugin activate zw-knabbel-wp
 wp option update connectors_ai_openai_api_key e2e-openai-key
 # The dollar-prefixed variables are evaluated by PHP inside the container.

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -131,7 +131,7 @@ wp core install \
 	--locale=en_US \
 	--skip-email
 wp option update timezone_string Europe/Amsterdam
-wp plugin install ai-provider-for-openai --version=1.0.3 --activate
+wp plugin install ai-provider-for-openai --activate
 wp plugin install classic-editor --activate
 wp plugin activate zw-knabbel-wp
 wp option update connectors_ai_openai_api_key e2e-openai-key

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -132,7 +132,7 @@ wp core install \
 	--skip-email
 wp option update timezone_string Europe/Amsterdam
 wp plugin install ai-provider-for-openai --version=1.0.3 --activate
-wp plugin install classic-editor --version=1.7.0 --activate
+wp plugin install classic-editor --activate
 wp plugin activate zw-knabbel-wp
 wp option update connectors_ai_openai_api_key e2e-openai-key
 # The dollar-prefixed variables are evaluated by PHP inside the container.

--- a/tests/playwright/utils.ts
+++ b/tests/playwright/utils.ts
@@ -116,13 +116,23 @@ export async function setBabbelEnabled(
     page: Page,
     enabled: boolean,
 ): Promise<void> {
-    const checkbox = page.locator(
-        '#knabbel-radionieuws #knabbel_send_to_babbel',
-    );
-    await expect(checkbox).toBeVisible();
+    const checkbox = page.locator('#knabbel_send_to_babbel');
+    const toggle = page.locator('.misc-pub-knabbel .knabbel-submitbox-toggle');
+
+    await expect(toggle).toBeVisible();
     await expect(checkbox).toBeEnabled();
-    await checkbox.setChecked(enabled);
+
+    if ((await checkbox.isChecked()) !== enabled) {
+        await toggle.click();
+    }
     await expect(checkbox).toBeChecked({ checked: enabled });
+    await expect(
+        toggle.locator(
+            enabled
+                ? '.knabbel-submitbox-toggle-enabled'
+                : '.knabbel-submitbox-toggle-disabled',
+        ),
+    ).toBeVisible();
 }
 
 export async function controlStory(

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -6,6 +6,7 @@
  * Version: 0.5.0
  * Requires at least: 7.0
  * Requires PHP: 8.3
+ * Requires Plugins: classic-editor
  * Author: Streekomroep ZuidWest
  * Author URI: https://www.zuidwesttv.nl
  * License: MIT

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -447,6 +447,8 @@ function get_story_sync_error( array $state ): ?array {
  * @since 0.4.0
  * @param array<string, mixed>|null $sync_error Sync error data.
  * @return bool Whether the sync error can be rendered.
+ *
+ * @phpstan-assert-if-true !null $sync_error
  */
 function is_story_sync_error_renderable( ?array $sync_error ): bool {
 	return null !== $sync_error


### PR DESCRIPTION
## Summary

- move the Radio News checkbox from a separate metabox into the Publish box
- add an accessible Yes/No toggle styled for the WordPress admin
- keep the visually hidden checkbox focusable without intercepting label clicks
- update Playwright helpers, documentation, and translations
- add a PHPStan assertion for renderable sync errors

## Testing

- `vendor/bin/phpcs`
- `composer phpstan`
- `npm run lint`
- `git diff --check`
- `BABBEL_PATH=/Users/rmens/Documents/GitHub/zwfm-babbel tests/e2e/run.sh`
  - 7 Playwright browser tests passed
  - 18 regression scenarios passed with 252 assertions