### PR TITLE
fix(tooling): support WordPress 7 static analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Publishes selected WordPress posts as radio stories in the [Babbel API](https://
 composer install
 npm install
 vendor/bin/phpcs
-vendor/bin/phpstan analyse
+composer phpstan
 npm run lint
 shellcheck tests/e2e/run.sh
 ```

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "php-stubs/wordpress-stubs": "7.0.1 as 6.9.99",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpstan/extension-installer": "^1.3",
+    "phpstan/phpstan": "^2.2",
     "squizlabs/php_codesniffer": "^3.8",
     "szepeviktor/phpstan-wordpress": "^2.0",
     "wp-coding-standards/wpcs": "^3.0"
@@ -33,5 +34,8 @@
       "phpstan/extension-installer": true
     },
     "sort-packages": true
+  },
+  "scripts": {
+    "phpstan": "@php -d memory_limit=2G vendor/bin/phpstan analyse --no-progress"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07c459824255a021105e3eeba1787572",
+    "content-hash": "1e15ca899d094f9013db6ecf5a5a7859",
     "packages": [
         {
             "name": "woocommerce/action-scheduler",
@@ -641,11 +641,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.33",
+            "version": "2.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
-                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
                 "shasum": ""
             },
             "require": {
@@ -667,6 +667,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -690,20 +701,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T10:24:31+00:00"
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -769,7 +780,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",


### PR DESCRIPTION
## Summary

- make PHPStan an explicit dev dependency and update it from 2.1.33 to 2.2.8
- add `composer phpstan`, which allocates enough memory for the official WordPress 7 stub and runs without relying on a warm result cache
- update PHP_CodeSniffer to 3.13.6, resolving CVE-2026-67434
- document the canonical PHPStan command

## Root cause

The seven unresolved AI Client symbols came from a stale local `vendor/` directory containing WordPress stubs 6.9.0, while `composer.lock` already specified 7.0.1. After `composer install`, those symbols resolve correctly. The WordPress 7 stub is substantially larger and a cold analysis exceeds 512 MB, so the canonical Composer script uses a 2 GB limit.

The plugin remains compatible with WordPress 7.0+. WordPress 7.0.3 is the deployed version, but no `php-stubs/wordpress-stubs` 7.0.3 release or official `wordpress:7.0.3-php8.3-apache` Docker image is currently available.

## Testing

- `composer validate --no-check-publish`
- `composer audit --locked`
- `vendor/bin/phpstan clear-result-cache && composer phpstan`
- `vendor/bin/phpcs`
- `npm run lint`
- `shellcheck tests/e2e/run.sh`
- `BABBEL_PATH=/Users/rmens/Documents/GitHub/zwfm-babbel docker compose -f tests/e2e/compose.yml config --quiet`
- verified `wordpress:7.0.2-php8.3-apache` exists in the official Docker registry