### PR TITLE
feat(ai): add selectable generation model

### DIFF
--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -89,6 +89,7 @@ function settings_register_settings(): void {
 				'api_base_url'      => '',
 				'api_username'      => '',
 				'api_password'      => '',
+				'ai_model'          => '',
 				'speech_prompt'     => '',
 				'debug_mode'        => false,
 				'start_days_offset' => 1,
@@ -123,7 +124,7 @@ function sanitize_settings( array $input ): array {
 	}
 
 	// Text fields.
-	$text_fields = array( 'api_username', 'api_password' );
+	$text_fields = array( 'api_username', 'api_password', 'ai_model' );
 	foreach ( $text_fields as $field ) {
 		if ( isset( $input[ $field ] ) ) {
 			$sanitized[ $field ] = sanitize_text_field( $input[ $field ] );
@@ -453,6 +454,7 @@ function render_babbel_api_card( array $settings ): void {
  * @param array<string, mixed> $settings Current settings.
  */
 function render_ai_card( array $settings ): void {
+	$ai_models = ai_get_available_models();
 	?>
 	<div class="knabbel-settings-card">
 		<div class="knabbel-card-title">
@@ -466,6 +468,35 @@ function render_ai_card( array $settings ): void {
 					<?php esc_html_e( 'Manage AI providers', 'zw-knabbel-wp' ); ?>
 				</a>
 			</p>
+
+			<?php if ( array() !== $ai_models ) : ?>
+				<div class="knabbel-field">
+					<label class="knabbel-field-label" for="knabbel-ai-model">
+						<?php esc_html_e( 'AI Model', 'zw-knabbel-wp' ); ?>
+					</label>
+					<select id="knabbel-ai-model" name="knabbel_settings[ai_model]" class="knabbel-field-input">
+						<option value=""><?php esc_html_e( 'Automatic', 'zw-knabbel-wp' ); ?></option>
+						<?php foreach ( $ai_models as $provider_id => $provider_data ) : ?>
+							<optgroup label="<?php echo esc_attr( $provider_data['label'] ); ?>">
+								<?php foreach ( $provider_data['models'] as $model_id => $model_name ) : ?>
+									<?php $model_value = $provider_id . '/' . $model_id; ?>
+									<option value="<?php echo esc_attr( $model_value ); ?>" <?php selected( $settings['ai_model'] ?? '', $model_value ); ?>>
+										<?php echo esc_html( $model_name ); ?>
+									</option>
+								<?php endforeach; ?>
+							</optgroup>
+						<?php endforeach; ?>
+					</select>
+					<p class="knabbel-field-description">
+						<?php esc_html_e( 'Choose a configured text model, or let WordPress select one automatically.', 'zw-knabbel-wp' ); ?>
+					</p>
+				</div>
+			<?php else : ?>
+				<input type="hidden" name="knabbel_settings[ai_model]" value="<?php echo esc_attr( $settings['ai_model'] ?? '' ); ?>" />
+				<p class="knabbel-field-description">
+					<?php esc_html_e( 'No configured text generation models are available.', 'zw-knabbel-wp' ); ?>
+				</p>
+			<?php endif; ?>
 
 			<div class="knabbel-field">
 				<label class="knabbel-field-label" for="knabbel-speech-prompt">

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -124,11 +124,17 @@ function sanitize_settings( array $input ): array {
 	}
 
 	// Text fields.
-	$text_fields = array( 'api_username', 'api_password', 'ai_model' );
+	$text_fields = array( 'api_username', 'api_password' );
 	foreach ( $text_fields as $field ) {
 		if ( isset( $input[ $field ] ) ) {
 			$sanitized[ $field ] = sanitize_text_field( $input[ $field ] );
 		}
+	}
+
+	// Model select: empty means automatic, anything else must be "provider/model".
+	if ( isset( $input['ai_model'] ) ) {
+		$ai_model              = sanitize_text_field( $input['ai_model'] );
+		$sanitized['ai_model'] = null !== ai_parse_model_setting( $ai_model ) ? $ai_model : '';
 	}
 
 	// Textarea fields (prompts) - preserve newlines.
@@ -476,10 +482,9 @@ function render_ai_card( array $settings ): void {
 					</label>
 					<select id="knabbel-ai-model" name="knabbel_settings[ai_model]" class="knabbel-field-input">
 						<option value=""><?php esc_html_e( 'Automatic', 'zw-knabbel-wp' ); ?></option>
-						<?php foreach ( $ai_models as $provider_id => $provider_data ) : ?>
+						<?php foreach ( $ai_models as $provider_data ) : ?>
 							<optgroup label="<?php echo esc_attr( $provider_data['label'] ); ?>">
-								<?php foreach ( $provider_data['models'] as $model_id => $model_name ) : ?>
-									<?php $model_value = $provider_id . '/' . $model_id; ?>
+								<?php foreach ( $provider_data['models'] as $model_value => $model_name ) : ?>
 									<option value="<?php echo esc_attr( $model_value ); ?>" <?php selected( $settings['ai_model'] ?? '', $model_value ); ?>>
 										<?php echo esc_html( $model_name ); ?>
 									</option>
@@ -492,6 +497,7 @@ function render_ai_card( array $settings ): void {
 					</p>
 				</div>
 			<?php else : ?>
+				<?php // The hidden field preserves the stored value: sanitize_settings() drops keys absent from the form. ?>
 				<input type="hidden" name="knabbel_settings[ai_model]" value="<?php echo esc_attr( $settings['ai_model'] ?? '' ); ?>" />
 				<p class="knabbel-field-description">
 					<?php esc_html_e( 'No configured text generation models are available.', 'zw-knabbel-wp' ); ?>

--- a/includes/ai-handler.php
+++ b/includes/ai-handler.php
@@ -12,9 +12,12 @@ declare(strict_types=1);
 
 namespace KnabbelWP;
 
+use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -23,6 +26,43 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:ignore Generic.Files.LineLength.TooLong -- Keeping the prompt literal intact makes it easy to review and reuse.
 const AI_DEFAULT_INSTRUCTION = "Transformeer naar natuurlijke radiospreektekst met:\n- Korte, heldere zinnen (max 15 woorden)\n- Spreektaal en radiofrases\n- Logische volgorde voor luisteraars\n- Duidelijke overgangen tussen punten\n- Actieve zinsbouw\n- Getallen uitgeschreven waar natuurlijk";
 const AI_ARTICLE_PROMPT      = "Artikel:\n\"\"\"\n%s\n\"\"\"";
+
+/**
+ * Get configured AI models that support text generation.
+ *
+ * @since 0.6.0
+ * @return array<string, array{label: string, models: array<string, string>}>
+ */
+function ai_get_available_models(): array {
+	if ( ! function_exists( 'wp_supports_ai' ) || ! wp_supports_ai() ) {
+		return array();
+	}
+
+	try {
+		$requirements = new ModelRequirements( array( CapabilityEnum::textGeneration() ), array() );
+		$models       = array();
+
+		foreach ( AiClient::defaultRegistry()->findModelsMetadataForSupport( $requirements ) as $provider_models_metadata ) {
+			$provider        = $provider_models_metadata->getProvider();
+			$provider_models = array();
+
+			foreach ( $provider_models_metadata->getModels() as $model ) {
+				$provider_models[ $model->getId() ] = $model->getName();
+			}
+
+			if ( array() !== $provider_models ) {
+				$models[ $provider->getId() ] = array(
+					'label'  => $provider->getName(),
+					'models' => $provider_models,
+				);
+			}
+		}
+
+		return $models;
+	} catch ( \Throwable ) {
+		return array();
+	}
+}
 
 /**
  * Generate speech text through the WordPress AI Client.
@@ -57,10 +97,17 @@ function ai_generate_content( string $content ): ?string {
 
 	$max_attempts = 3;
 	for ( $attempt = 1; $attempt <= $max_attempts; ++$attempt ) {
-		$prompt = wp_ai_client_prompt( $messages )
+		$prompt        = wp_ai_client_prompt( $messages )
 			->using_system_instruction( $instruction )
 			->using_max_tokens( 1000 )
 			->using_temperature( 0.7 );
+		$model_setting = $options['ai_model'] ?? '';
+		if ( is_string( $model_setting ) && str_contains( $model_setting, '/' ) ) {
+			list( $provider_id, $model_id ) = explode( '/', $model_setting, 2 );
+			if ( '' !== $provider_id && '' !== $model_id ) {
+				$prompt = $prompt->using_model_preference( array( $provider_id, $model_id ) );
+			}
+		}
 
 		if ( 1 === $attempt && ! $prompt->is_supported_for_text_generation() ) {
 			log( 'error', 'AiHandler', 'WordPress AI Client does not support text generation for this prompt' );

--- a/includes/ai-handler.php
+++ b/includes/ai-handler.php
@@ -30,6 +30,8 @@ const AI_ARTICLE_PROMPT      = "Artikel:\n\"\"\"\n%s\n\"\"\"";
 /**
  * Get configured AI models that support text generation.
  *
+ * Model keys are "provider/model" setting values as understood by ai_parse_model_setting().
+ *
  * @since 0.6.0
  * @return array<string, array{label: string, models: array<string, string>}>
  */
@@ -47,7 +49,7 @@ function ai_get_available_models(): array {
 			$provider_models = array();
 
 			foreach ( $provider_models_metadata->getModels() as $model ) {
-				$provider_models[ $model->getId() ] = $model->getName();
+				$provider_models[ $provider->getId() . '/' . $model->getId() ] = $model->getName();
 			}
 
 			if ( array() !== $provider_models ) {
@@ -59,9 +61,26 @@ function ai_get_available_models(): array {
 		}
 
 		return $models;
-	} catch ( \Throwable ) {
+	} catch ( \Throwable $e ) {
+		log( 'error', 'AiHandler', 'Could not list AI models', array( 'error' => $e->getMessage() ) );
 		return array();
 	}
+}
+
+/**
+ * Parse a "provider/model" ai_model setting value into a model preference tuple.
+ *
+ * @since 0.6.0
+ * @param mixed $value The stored setting value.
+ * @return array{0: string, 1: string}|null Provider and model ID, or null when unset or malformed.
+ */
+function ai_parse_model_setting( mixed $value ): ?array {
+	if ( ! is_string( $value ) ) {
+		return null;
+	}
+
+	$parts = explode( '/', $value, 2 );
+	return 2 === count( $parts ) && ! in_array( '', $parts, true ) ? $parts : null;
 }
 
 /**
@@ -95,18 +114,16 @@ function ai_generate_content( string $content ): ?string {
 	}
 	$messages[] = new UserMessage( array( new MessagePart( sprintf( AI_ARTICLE_PROMPT, $content ) ) ) );
 
+	$model_preference = ai_parse_model_setting( $options['ai_model'] ?? '' );
+
 	$max_attempts = 3;
 	for ( $attempt = 1; $attempt <= $max_attempts; ++$attempt ) {
-		$prompt        = wp_ai_client_prompt( $messages )
+		$prompt = wp_ai_client_prompt( $messages )
 			->using_system_instruction( $instruction )
 			->using_max_tokens( 1000 )
 			->using_temperature( 0.7 );
-		$model_setting = $options['ai_model'] ?? '';
-		if ( is_string( $model_setting ) && str_contains( $model_setting, '/' ) ) {
-			list( $provider_id, $model_id ) = explode( '/', $model_setting, 2 );
-			if ( '' !== $provider_id && '' !== $model_id ) {
-				$prompt = $prompt->using_model_preference( array( $provider_id, $model_id ) );
-			}
+		if ( null !== $model_preference ) {
+			$prompt = $prompt->using_model_preference( $model_preference );
 		}
 
 		if ( 1 === $attempt && ! $prompt->is_supported_for_text_generation() ) {

--- a/languages/zw-knabbel-wp-nl_NL.po
+++ b/languages/zw-knabbel-wp-nl_NL.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ZuidWest Knabbel 0.5.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
-"POT-Creation-Date: 2026-07-26T21:56:40+00:00\n"
-"PO-Revision-Date: 2026-07-26T20:34:04+00:00\n"
+"POT-Creation-Date: 2026-08-11T14:51:44+00:00\n"
+"PO-Revision-Date: 2026-08-11T14:51:44+00:00\n"
 "Last-Translator: Remon Mens\n"
 "Language-Team: Dutch\n"
 "Language: nl_NL\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #. Plugin Name of the plugin
 #: zw-knabbel-wp.php includes/admin/settings.php:66
-#: includes/admin/settings.php:228
+#: includes/admin/settings.php:229
 msgid "ZuidWest Knabbel"
 msgstr "ZuidWest Knabbel"
 
@@ -42,69 +42,69 @@ msgstr ""
 msgid "https://www.zuidwesttv.nl"
 msgstr ""
 
-#: includes/admin/metabox.php:70 includes/admin/metabox.php:115
+#: includes/admin/metabox.php:62 includes/admin/metabox.php:107
 msgid "Radio News"
 msgstr "Radionieuws"
 
-#: includes/admin/metabox.php:90
+#: includes/admin/metabox.php:82
 msgid "Knabbel Status"
 msgstr "Knabbel Status"
 
-#: includes/admin/metabox.php:121
+#: includes/admin/metabox.php:113
 msgid "Babbel sync warning"
 msgstr "Waarschuwing bij Babbel-synchronisatie"
 
-#: includes/admin/metabox.php:145 includes/admin/settings.php:561
-#: includes/admin/settings.php:740
+#: includes/admin/metabox.php:137 includes/admin/settings.php:592
+#: includes/admin/settings.php:771
 msgid "Status"
 msgstr "Status"
 
-#: includes/admin/metabox.php:149 includes/admin/settings.php:684
+#: includes/admin/metabox.php:141 includes/admin/settings.php:715
 msgid "Scheduled"
 msgstr "Ingepland"
 
-#: includes/admin/metabox.php:150 includes/admin/settings.php:685
+#: includes/admin/metabox.php:142 includes/admin/settings.php:716
 msgid "Processing"
 msgstr "Bezig"
 
-#: includes/admin/metabox.php:151 includes/admin/settings.php:686
+#: includes/admin/metabox.php:143 includes/admin/settings.php:717
 msgid "Sent"
 msgstr "Verzonden"
 
-#: includes/admin/metabox.php:152 includes/admin/settings.php:687
+#: includes/admin/metabox.php:144 includes/admin/settings.php:718
 msgid "Error"
 msgstr "Fout"
 
-#: includes/admin/metabox.php:153
+#: includes/admin/metabox.php:145
 msgid "Deleted"
 msgstr "Verwijderd"
 
-#: includes/admin/metabox.php:155
+#: includes/admin/metabox.php:147
 msgid "—"
 msgstr "—"
 
-#: includes/admin/metabox.php:161
+#: includes/admin/metabox.php:153
 msgid "Last status change:"
 msgstr "Laatste statuswijziging:"
 
-#: includes/admin/metabox.php:171
+#: includes/admin/metabox.php:163
 msgid "Story ID"
 msgstr "Verhaal-ID"
 
-#: includes/admin/metabox.php:177
+#: includes/admin/metabox.php:169
 msgid "Scheduled:"
 msgstr "Ingepland:"
 
-#: includes/admin/metabox.php:186 includes/admin/settings.php:778
+#: includes/admin/metabox.php:178 includes/admin/settings.php:809
 msgid "Last sync error"
 msgstr "Laatste synchronisatiefout"
 
-#: includes/admin/metabox.php:192 includes/admin/settings.php:783
+#: includes/admin/metabox.php:184 includes/admin/settings.php:814
 msgid "Operation"
 msgstr "Bewerking"
 
-#: includes/admin/metabox.php:210 includes/admin/settings.php:297
-#: includes/admin/settings.php:762 includes/admin/settings.php:767
+#: includes/admin/metabox.php:202 includes/admin/settings.php:298
+#: includes/admin/settings.php:793 includes/admin/settings.php:798
 msgid "Message"
 msgstr "Bericht"
 
@@ -116,87 +116,87 @@ msgstr "Je hebt onvoldoende rechten om deze actie uit te voeren."
 msgid "ZuidWest Knabbel Settings"
 msgstr "ZuidWest Knabbel Instellingen"
 
-#: includes/admin/settings.php:179
+#: includes/admin/settings.php:180
 msgid "You do not have sufficient permissions to view this page."
 msgstr "Je hebt onvoldoende rechten om deze pagina te bekijken."
 
-#: includes/admin/settings.php:204
+#: includes/admin/settings.php:205
 msgid "Testing..."
 msgstr "Testen..."
 
-#: includes/admin/settings.php:205 includes/admin/settings.php:440
+#: includes/admin/settings.php:206 includes/admin/settings.php:441
 msgid "Test API Connection"
 msgstr "Test API-verbinding"
 
-#: includes/admin/settings.php:206
+#: includes/admin/settings.php:207
 msgid "An error occurred"
 msgstr "Er is een fout opgetreden"
 
-#: includes/admin/settings.php:219
+#: includes/admin/settings.php:220
 msgid "Recent errors cleared."
 msgstr "Recente fouten gewist."
 
-#: includes/admin/settings.php:223
+#: includes/admin/settings.php:224
 msgid "Recent errors could not be cleared. Please try again."
 msgstr "Recente fouten konden niet worden gewist. Probeer het opnieuw."
 
-#: includes/admin/settings.php:230
+#: includes/admin/settings.php:231
 msgid "Wijzigingen opslaan"
 msgstr "Wijzigingen opslaan"
 
-#: includes/admin/settings.php:288
+#: includes/admin/settings.php:289
 msgid "Recent Errors"
 msgstr "Recente fouten"
 
-#: includes/admin/settings.php:295
+#: includes/admin/settings.php:296
 msgid "Time"
 msgstr "Tijd"
 
-#: includes/admin/settings.php:296
+#: includes/admin/settings.php:297
 msgid "Component"
 msgstr "Onderdeel"
 
-#: includes/admin/settings.php:303
+#: includes/admin/settings.php:304
 msgid "No valid recent errors to display."
 msgstr "Geen geldige recente fouten om weer te geven."
 
-#: includes/admin/settings.php:334
+#: includes/admin/settings.php:335
 msgid "Clear Errors"
 msgstr "Fouten wissen"
 
-#: includes/admin/settings.php:375
+#: includes/admin/settings.php:376
 msgid "Babbel API"
 msgstr "Babbel API"
 
-#: includes/admin/settings.php:379
+#: includes/admin/settings.php:380
 msgid "Configure the Babbel API settings."
 msgstr "Configureer de Babbel API-instellingen."
 
-#: includes/admin/settings.php:384
+#: includes/admin/settings.php:385
 msgid "Babbel API Base URL"
 msgstr "Babbel API basis-URL"
 
-#: includes/admin/settings.php:393
+#: includes/admin/settings.php:394
 msgid "The base URL of the Babbel API (without trailing slash)."
 msgstr "De basis-URL van de Babbel API (zonder afsluitende slash)."
 
-#: includes/admin/settings.php:400
+#: includes/admin/settings.php:401
 msgid "Babbel API Username"
 msgstr "Babbel API-gebruikersnaam"
 
-#: includes/admin/settings.php:407
+#: includes/admin/settings.php:408
 msgid "username"
 msgstr "gebruikersnaam"
 
-#: includes/admin/settings.php:412
+#: includes/admin/settings.php:413
 msgid "Babbel API Password"
 msgstr "Babbel API-wachtwoord"
 
-#: includes/admin/settings.php:430
+#: includes/admin/settings.php:431
 msgid "Enable Debug Mode"
 msgstr "Debug-modus inschakelen"
 
-#: includes/admin/settings.php:434
+#: includes/admin/settings.php:435
 msgid ""
 "Show debug information and status in the sidebar. Only enable for "
 "troubleshooting."
@@ -204,24 +204,44 @@ msgstr ""
 "Toon debug-informatie en status in de zijbalk. Alleen inschakelen voor "
 "probleemoplossing."
 
-#: includes/admin/settings.php:460
+#: includes/admin/settings.php:462
 msgid "AI Generation"
 msgstr "AI-generatie"
 
-#: includes/admin/settings.php:464
+#: includes/admin/settings.php:466
 msgid "WordPress selects a suitable model from your configured AI providers."
 msgstr ""
 "WordPress selecteert een geschikt model uit je geconfigureerde AI-providers."
 
-#: includes/admin/settings.php:466
+#: includes/admin/settings.php:468
 msgid "Manage AI providers"
 msgstr "AI-providers beheren"
 
-#: includes/admin/settings.php:472
+#: includes/admin/settings.php:475
+msgid "AI Model"
+msgstr "AI-model"
+
+#: includes/admin/settings.php:478
+msgid "Automatic"
+msgstr "Automatisch"
+
+#: includes/admin/settings.php:491
+msgid ""
+"Choose a configured text model, or let WordPress select one automatically."
+msgstr ""
+"Kies een geconfigureerd tekstmodel of laat WordPress er automatisch een "
+"selecteren."
+
+#: includes/admin/settings.php:497
+msgid "No configured text generation models are available."
+msgstr ""
+"Er zijn geen geconfigureerde modellen voor tekstgeneratie beschikbaar."
+
+#: includes/admin/settings.php:503
 msgid "Speech Text Generation Prompt"
 msgstr "Prompt voor spreektekstgeneratie"
 
-#: includes/admin/settings.php:480
+#: includes/admin/settings.php:511
 msgid ""
 "Prompt for converting to radio-friendly speech text. Leave empty for default "
 "prompt."
@@ -229,11 +249,11 @@ msgstr ""
 "Prompt voor het converteren naar radiogeschikte spreektekst. Laat leeg voor "
 "standaardprompt."
 
-#: includes/admin/settings.php:486
+#: includes/admin/settings.php:517
 msgid "Few-shot Examples"
 msgstr "Few-shot voorbeelden"
 
-#: includes/admin/settings.php:497
+#: includes/admin/settings.php:528
 msgid ""
 "Number of editor-corrected examples to include in the speech prompt (0 to "
 "disable, max 20). Synced nightly from Babbel."
@@ -242,99 +262,99 @@ msgstr ""
 "om uit te schakelen, max 20). Wordt elke nacht gesynchroniseerd vanuit "
 "Babbel."
 
-#: includes/admin/settings.php:517
+#: includes/admin/settings.php:548
 msgid "Sun"
 msgstr "Zo"
 
-#: includes/admin/settings.php:518
+#: includes/admin/settings.php:549
 msgid "Mon"
 msgstr "Ma"
 
-#: includes/admin/settings.php:519
+#: includes/admin/settings.php:550
 msgid "Tue"
 msgstr "Di"
 
-#: includes/admin/settings.php:520
+#: includes/admin/settings.php:551
 msgid "Wed"
 msgstr "Wo"
 
-#: includes/admin/settings.php:521
+#: includes/admin/settings.php:552
 msgid "Thu"
 msgstr "Do"
 
-#: includes/admin/settings.php:522
+#: includes/admin/settings.php:553
 msgid "Fri"
 msgstr "Vr"
 
-#: includes/admin/settings.php:523
+#: includes/admin/settings.php:554
 msgid "Sat"
 msgstr "Za"
 
-#: includes/admin/settings.php:530
+#: includes/admin/settings.php:561
 msgid "Story Defaults"
 msgstr "Standaardinstellingen verhaal"
 
-#: includes/admin/settings.php:535
+#: includes/admin/settings.php:566
 msgid "Start Date (days from now)"
 msgstr "Startdatum (dagen vanaf nu)"
 
-#: includes/admin/settings.php:543
+#: includes/admin/settings.php:574
 msgid "Number of days from publication for start date."
 msgstr "Aantal dagen vanaf publicatie voor startdatum."
 
-#: includes/admin/settings.php:548
+#: includes/admin/settings.php:579
 msgid "End Date (days from now)"
 msgstr "Einddatum (dagen vanaf nu)"
 
-#: includes/admin/settings.php:556
+#: includes/admin/settings.php:587
 msgid "Number of days from publication for end date."
 msgstr "Aantal dagen vanaf publicatie voor einddatum."
 
-#: includes/admin/settings.php:570
+#: includes/admin/settings.php:601
 msgid "Active"
 msgstr "Actief"
 
-#: includes/admin/settings.php:575
+#: includes/admin/settings.php:606
 msgid "Days"
 msgstr "Dagen"
 
-#: includes/admin/settings.php:593
+#: includes/admin/settings.php:624
 msgid "Which days the story may be broadcast."
 msgstr "Op welke dagen het verhaal uitgezonden mag worden."
 
-#: includes/admin/settings.php:711
+#: includes/admin/settings.php:742
 msgid "Knabbel Story Debug Overview"
 msgstr "Knabbel verhaal debug-overzicht"
 
-#: includes/admin/settings.php:725
+#: includes/admin/settings.php:756
 msgid "Show"
 msgstr "Tonen"
 
-#: includes/admin/settings.php:731
+#: includes/admin/settings.php:762
 msgid "Article"
 msgstr "Artikel"
 
-#: includes/admin/settings.php:749
+#: includes/admin/settings.php:780
 msgid "Last status change"
 msgstr "Laatste statuswijziging"
 
-#: includes/admin/settings.php:756 includes/admin/settings.php:772
+#: includes/admin/settings.php:787 includes/admin/settings.php:803
 msgid "Babbel ID"
 msgstr "Babbel ID"
 
-#: includes/admin/settings.php:768 zw-knabbel-wp.php:691
+#: includes/admin/settings.php:799 zw-knabbel-wp.php:693
 msgid "Story is being processed..."
 msgstr "Verhaal wordt verwerkt..."
 
-#: includes/admin/settings.php:792
+#: includes/admin/settings.php:823
 msgid "Occurred"
 msgstr "Opgetreden"
 
-#: includes/admin/settings.php:808
+#: includes/admin/settings.php:839
 msgid "Retry"
 msgstr "Opnieuw verzenden"
 
-#: includes/admin/settings.php:813
+#: includes/admin/settings.php:844
 msgid "Refresh"
 msgstr "Vernieuwen"
 
@@ -378,7 +398,7 @@ msgstr "API-fout"
 msgid "No story ID received from API"
 msgstr "Geen verhaal-ID ontvangen van API"
 
-#: includes/babbel-api.php:325 zw-knabbel-wp.php:746
+#: includes/babbel-api.php:325 zw-knabbel-wp.php:748
 msgid "Story created successfully"
 msgstr "Verhaal succesvol aangemaakt"
 
@@ -436,58 +456,58 @@ msgstr "Babbel API basis-URL niet geconfigureerd"
 msgid "API error: HTTP %d"
 msgstr "API-fout: HTTP %d"
 
-#: includes/post-hooks.php:210
+#: includes/post-hooks.php:113
 msgid "Story deleted from Babbel"
 msgstr "Verhaal verwijderd uit Babbel"
 
-#: includes/post-hooks.php:300
-msgid "Story updated (post published)"
-msgstr "Verhaal bijgewerkt (bericht gepubliceerd)"
-
-#: includes/post-hooks.php:335
-msgid "Story updated in Babbel"
-msgstr "Verhaal bijgewerkt in Babbel"
-
-#: includes/post-hooks.php:354
-msgid "Story deleted (post unscheduled)"
-msgstr "Verhaal verwijderd (bericht niet meer ingepland)"
-
-#: includes/post-hooks.php:385
+#: includes/post-hooks.php:116
 msgid "Story deleted (post trashed)"
 msgstr "Verhaal verwijderd (bericht in prullenbak)"
 
-#: includes/post-hooks.php:450 includes/post-hooks.php:470
+#: includes/post-hooks.php:119
+msgid "Story deleted (post unscheduled)"
+msgstr "Verhaal verwijderd (bericht niet meer ingepland)"
+
+#: includes/post-hooks.php:162
+msgid "Story updated (post published)"
+msgstr "Verhaal bijgewerkt (bericht gepubliceerd)"
+
+#: includes/post-hooks.php:175
+msgid "Story updated in Babbel"
+msgstr "Verhaal bijgewerkt in Babbel"
+
+#: includes/post-hooks.php:214 includes/post-hooks.php:234
 msgid "Story restored in Babbel"
 msgstr "Verhaal hersteld in Babbel"
 
-#: includes/post-hooks.php:640
+#: includes/post-hooks.php:404
 msgid "Processing already scheduled"
 msgstr "Verwerking al ingepland"
 
-#: includes/post-hooks.php:659
+#: includes/post-hooks.php:423
 msgid "Processing scheduled"
 msgstr "Verwerking ingepland"
 
-#: includes/post-hooks.php:667
+#: includes/post-hooks.php:431
 msgid "Could not schedule action"
 msgstr "Kon actie niet inplannen"
 
-#: zw-knabbel-wp.php:616
+#: zw-knabbel-wp.php:618
 msgid "Insufficient permissions"
 msgstr "Onvoldoende rechten"
 
-#: zw-knabbel-wp.php:655
+#: zw-knabbel-wp.php:657
 msgid "Already sent — skipping"
 msgstr "Al verzonden — wordt overgeslagen"
 
-#: zw-knabbel-wp.php:667
+#: zw-knabbel-wp.php:669
 msgid "Post not found"
 msgstr "Bericht niet gevonden"
 
-#: zw-knabbel-wp.php:680
+#: zw-knabbel-wp.php:682
 msgid "Send to Babbel is disabled for this post"
 msgstr "Verzenden naar Babbel is uitgeschakeld voor dit bericht"
 
-#: zw-knabbel-wp.php:707
+#: zw-knabbel-wp.php:709
 msgid "Could not generate speech text"
 msgstr "Kon spreektekst niet genereren"

--- a/languages/zw-knabbel-wp-nl_NL.po
+++ b/languages/zw-knabbel-wp-nl_NL.po
@@ -2,19 +2,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ZuidWest Knabbel 0.5.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
-"POT-Creation-Date: 2026-08-11T14:51:44+00:00\n"
-"PO-Revision-Date: 2026-08-11T14:51:44+00:00\n"
 "Last-Translator: Remon Mens\n"
 "Language-Team: Dutch\n"
-"Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-08-11T14:51:44+00:00\n"
+"PO-Revision-Date: 2026-08-11T14:51:44+00:00\n"
+"Language: nl_NL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Plugin Name of the plugin
-#: zw-knabbel-wp.php includes/admin/settings.php:66
-#: includes/admin/settings.php:229
+#: zw-knabbel-wp.php
+#: includes/admin/settings.php:66
+#: includes/admin/settings.php:235
 msgid "ZuidWest Knabbel"
 msgstr "ZuidWest Knabbel"
 
@@ -25,12 +26,8 @@ msgstr "https://github.com/oszuidwest/zw-knabbel-wp"
 
 #. Description of the plugin
 #: zw-knabbel-wp.php
-msgid ""
-"WordPress plugin om berichten naar de Babbel API te sturen voor het "
-"radionieuws. Gebruikt de WordPress AI Client voor AI-gegenereerde content."
-msgstr ""
-"WordPress plugin om berichten naar de Babbel API te sturen voor het "
-"radionieuws. Gebruikt de WordPress AI Client voor AI-gegenereerde content."
+msgid "WordPress plugin om berichten naar de Babbel API te sturen voor het radionieuws. Gebruikt de WordPress AI Client voor AI-gegenereerde content."
+msgstr "WordPress plugin om berichten naar de Babbel API te sturen voor het radionieuws. Gebruikt de WordPress AI Client voor AI-gegenereerde content."
 
 #. Author of the plugin
 #: zw-knabbel-wp.php
@@ -42,7 +39,8 @@ msgstr ""
 msgid "https://www.zuidwesttv.nl"
 msgstr ""
 
-#: includes/admin/metabox.php:62 includes/admin/metabox.php:107
+#: includes/admin/metabox.php:62
+#: includes/admin/metabox.php:107
 msgid "Radio News"
 msgstr "Radionieuws"
 
@@ -54,24 +52,29 @@ msgstr "Knabbel Status"
 msgid "Babbel sync warning"
 msgstr "Waarschuwing bij Babbel-synchronisatie"
 
-#: includes/admin/metabox.php:137 includes/admin/settings.php:592
-#: includes/admin/settings.php:771
+#: includes/admin/metabox.php:137
+#: includes/admin/settings.php:598
+#: includes/admin/settings.php:777
 msgid "Status"
 msgstr "Status"
 
-#: includes/admin/metabox.php:141 includes/admin/settings.php:715
+#: includes/admin/metabox.php:141
+#: includes/admin/settings.php:721
 msgid "Scheduled"
 msgstr "Ingepland"
 
-#: includes/admin/metabox.php:142 includes/admin/settings.php:716
+#: includes/admin/metabox.php:142
+#: includes/admin/settings.php:722
 msgid "Processing"
 msgstr "Bezig"
 
-#: includes/admin/metabox.php:143 includes/admin/settings.php:717
+#: includes/admin/metabox.php:143
+#: includes/admin/settings.php:723
 msgid "Sent"
 msgstr "Verzonden"
 
-#: includes/admin/metabox.php:144 includes/admin/settings.php:718
+#: includes/admin/metabox.php:144
+#: includes/admin/settings.php:724
 msgid "Error"
 msgstr "Fout"
 
@@ -95,16 +98,20 @@ msgstr "Verhaal-ID"
 msgid "Scheduled:"
 msgstr "Ingepland:"
 
-#: includes/admin/metabox.php:178 includes/admin/settings.php:809
+#: includes/admin/metabox.php:178
+#: includes/admin/settings.php:815
 msgid "Last sync error"
 msgstr "Laatste synchronisatiefout"
 
-#: includes/admin/metabox.php:184 includes/admin/settings.php:814
+#: includes/admin/metabox.php:184
+#: includes/admin/settings.php:820
 msgid "Operation"
 msgstr "Bewerking"
 
-#: includes/admin/metabox.php:202 includes/admin/settings.php:298
-#: includes/admin/settings.php:793 includes/admin/settings.php:798
+#: includes/admin/metabox.php:202
+#: includes/admin/settings.php:304
+#: includes/admin/settings.php:799
+#: includes/admin/settings.php:804
 msgid "Message"
 msgstr "Bericht"
 
@@ -116,253 +123,240 @@ msgstr "Je hebt onvoldoende rechten om deze actie uit te voeren."
 msgid "ZuidWest Knabbel Settings"
 msgstr "ZuidWest Knabbel Instellingen"
 
-#: includes/admin/settings.php:180
+#: includes/admin/settings.php:186
 msgid "You do not have sufficient permissions to view this page."
 msgstr "Je hebt onvoldoende rechten om deze pagina te bekijken."
 
-#: includes/admin/settings.php:205
+#: includes/admin/settings.php:211
 msgid "Testing..."
 msgstr "Testen..."
 
-#: includes/admin/settings.php:206 includes/admin/settings.php:441
+#: includes/admin/settings.php:212
+#: includes/admin/settings.php:447
 msgid "Test API Connection"
 msgstr "Test API-verbinding"
 
-#: includes/admin/settings.php:207
+#: includes/admin/settings.php:213
 msgid "An error occurred"
 msgstr "Er is een fout opgetreden"
 
-#: includes/admin/settings.php:220
+#: includes/admin/settings.php:226
 msgid "Recent errors cleared."
 msgstr "Recente fouten gewist."
 
-#: includes/admin/settings.php:224
+#: includes/admin/settings.php:230
 msgid "Recent errors could not be cleared. Please try again."
 msgstr "Recente fouten konden niet worden gewist. Probeer het opnieuw."
 
-#: includes/admin/settings.php:231
+#: includes/admin/settings.php:237
 msgid "Wijzigingen opslaan"
 msgstr "Wijzigingen opslaan"
 
-#: includes/admin/settings.php:289
+#: includes/admin/settings.php:295
 msgid "Recent Errors"
 msgstr "Recente fouten"
 
-#: includes/admin/settings.php:296
+#: includes/admin/settings.php:302
 msgid "Time"
 msgstr "Tijd"
 
-#: includes/admin/settings.php:297
+#: includes/admin/settings.php:303
 msgid "Component"
 msgstr "Onderdeel"
 
-#: includes/admin/settings.php:304
+#: includes/admin/settings.php:310
 msgid "No valid recent errors to display."
 msgstr "Geen geldige recente fouten om weer te geven."
 
-#: includes/admin/settings.php:335
+#: includes/admin/settings.php:341
 msgid "Clear Errors"
 msgstr "Fouten wissen"
 
-#: includes/admin/settings.php:376
+#: includes/admin/settings.php:382
 msgid "Babbel API"
 msgstr "Babbel API"
 
-#: includes/admin/settings.php:380
+#: includes/admin/settings.php:386
 msgid "Configure the Babbel API settings."
 msgstr "Configureer de Babbel API-instellingen."
 
-#: includes/admin/settings.php:385
+#: includes/admin/settings.php:391
 msgid "Babbel API Base URL"
 msgstr "Babbel API basis-URL"
 
-#: includes/admin/settings.php:394
+#: includes/admin/settings.php:400
 msgid "The base URL of the Babbel API (without trailing slash)."
 msgstr "De basis-URL van de Babbel API (zonder afsluitende slash)."
 
-#: includes/admin/settings.php:401
+#: includes/admin/settings.php:407
 msgid "Babbel API Username"
 msgstr "Babbel API-gebruikersnaam"
 
-#: includes/admin/settings.php:408
+#: includes/admin/settings.php:414
 msgid "username"
 msgstr "gebruikersnaam"
 
-#: includes/admin/settings.php:413
+#: includes/admin/settings.php:419
 msgid "Babbel API Password"
 msgstr "Babbel API-wachtwoord"
 
-#: includes/admin/settings.php:431
+#: includes/admin/settings.php:437
 msgid "Enable Debug Mode"
 msgstr "Debug-modus inschakelen"
 
-#: includes/admin/settings.php:435
-msgid ""
-"Show debug information and status in the sidebar. Only enable for "
-"troubleshooting."
-msgstr ""
-"Toon debug-informatie en status in de zijbalk. Alleen inschakelen voor "
-"probleemoplossing."
+#: includes/admin/settings.php:441
+msgid "Show debug information and status in the sidebar. Only enable for troubleshooting."
+msgstr "Toon debug-informatie en status in de zijbalk. Alleen inschakelen voor probleemoplossing."
 
-#: includes/admin/settings.php:462
+#: includes/admin/settings.php:468
 msgid "AI Generation"
 msgstr "AI-generatie"
 
-#: includes/admin/settings.php:466
+#: includes/admin/settings.php:472
 msgid "WordPress selects a suitable model from your configured AI providers."
-msgstr ""
-"WordPress selecteert een geschikt model uit je geconfigureerde AI-providers."
+msgstr "WordPress selecteert een geschikt model uit je geconfigureerde AI-providers."
 
-#: includes/admin/settings.php:468
+#: includes/admin/settings.php:474
 msgid "Manage AI providers"
 msgstr "AI-providers beheren"
 
-#: includes/admin/settings.php:475
+#: includes/admin/settings.php:481
 msgid "AI Model"
 msgstr "AI-model"
 
-#: includes/admin/settings.php:478
+#: includes/admin/settings.php:484
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: includes/admin/settings.php:491
-msgid ""
-"Choose a configured text model, or let WordPress select one automatically."
-msgstr ""
-"Kies een geconfigureerd tekstmodel of laat WordPress er automatisch een "
-"selecteren."
-
-#: includes/admin/settings.php:497
-msgid "No configured text generation models are available."
-msgstr ""
-"Er zijn geen geconfigureerde modellen voor tekstgeneratie beschikbaar."
+#: includes/admin/settings.php:496
+msgid "Choose a configured text model, or let WordPress select one automatically."
+msgstr "Kies een geconfigureerd tekstmodel of laat WordPress er automatisch een selecteren."
 
 #: includes/admin/settings.php:503
+msgid "No configured text generation models are available."
+msgstr "Er zijn geen geconfigureerde modellen voor tekstgeneratie beschikbaar."
+
+#: includes/admin/settings.php:509
 msgid "Speech Text Generation Prompt"
 msgstr "Prompt voor spreektekstgeneratie"
 
-#: includes/admin/settings.php:511
-msgid ""
-"Prompt for converting to radio-friendly speech text. Leave empty for default "
-"prompt."
-msgstr ""
-"Prompt voor het converteren naar radiogeschikte spreektekst. Laat leeg voor "
-"standaardprompt."
-
 #: includes/admin/settings.php:517
+msgid "Prompt for converting to radio-friendly speech text. Leave empty for default prompt."
+msgstr "Prompt voor het converteren naar radiogeschikte spreektekst. Laat leeg voor standaardprompt."
+
+#: includes/admin/settings.php:523
 msgid "Few-shot Examples"
 msgstr "Few-shot voorbeelden"
 
-#: includes/admin/settings.php:528
-msgid ""
-"Number of editor-corrected examples to include in the speech prompt (0 to "
-"disable, max 20). Synced nightly from Babbel."
-msgstr ""
-"Aantal door de redactie gecorrigeerde voorbeelden in de spreektekstprompt (0 "
-"om uit te schakelen, max 20). Wordt elke nacht gesynchroniseerd vanuit "
-"Babbel."
+#: includes/admin/settings.php:534
+msgid "Number of editor-corrected examples to include in the speech prompt (0 to disable, max 20). Synced nightly from Babbel."
+msgstr "Aantal door de redactie gecorrigeerde voorbeelden in de spreektekstprompt (0 om uit te schakelen, max 20). Wordt elke nacht gesynchroniseerd vanuit Babbel."
 
-#: includes/admin/settings.php:548
+#: includes/admin/settings.php:554
 msgid "Sun"
 msgstr "Zo"
 
-#: includes/admin/settings.php:549
+#: includes/admin/settings.php:555
 msgid "Mon"
 msgstr "Ma"
 
-#: includes/admin/settings.php:550
+#: includes/admin/settings.php:556
 msgid "Tue"
 msgstr "Di"
 
-#: includes/admin/settings.php:551
+#: includes/admin/settings.php:557
 msgid "Wed"
 msgstr "Wo"
 
-#: includes/admin/settings.php:552
+#: includes/admin/settings.php:558
 msgid "Thu"
 msgstr "Do"
 
-#: includes/admin/settings.php:553
+#: includes/admin/settings.php:559
 msgid "Fri"
 msgstr "Vr"
 
-#: includes/admin/settings.php:554
+#: includes/admin/settings.php:560
 msgid "Sat"
 msgstr "Za"
 
-#: includes/admin/settings.php:561
+#: includes/admin/settings.php:567
 msgid "Story Defaults"
 msgstr "Standaardinstellingen verhaal"
 
-#: includes/admin/settings.php:566
+#: includes/admin/settings.php:572
 msgid "Start Date (days from now)"
 msgstr "Startdatum (dagen vanaf nu)"
 
-#: includes/admin/settings.php:574
+#: includes/admin/settings.php:580
 msgid "Number of days from publication for start date."
 msgstr "Aantal dagen vanaf publicatie voor startdatum."
 
-#: includes/admin/settings.php:579
+#: includes/admin/settings.php:585
 msgid "End Date (days from now)"
 msgstr "Einddatum (dagen vanaf nu)"
 
-#: includes/admin/settings.php:587
+#: includes/admin/settings.php:593
 msgid "Number of days from publication for end date."
 msgstr "Aantal dagen vanaf publicatie voor einddatum."
 
-#: includes/admin/settings.php:601
+#: includes/admin/settings.php:607
 msgid "Active"
 msgstr "Actief"
 
-#: includes/admin/settings.php:606
+#: includes/admin/settings.php:612
 msgid "Days"
 msgstr "Dagen"
 
-#: includes/admin/settings.php:624
+#: includes/admin/settings.php:630
 msgid "Which days the story may be broadcast."
 msgstr "Op welke dagen het verhaal uitgezonden mag worden."
 
-#: includes/admin/settings.php:742
+#: includes/admin/settings.php:748
 msgid "Knabbel Story Debug Overview"
 msgstr "Knabbel verhaal debug-overzicht"
 
-#: includes/admin/settings.php:756
+#: includes/admin/settings.php:762
 msgid "Show"
 msgstr "Tonen"
 
-#: includes/admin/settings.php:762
+#: includes/admin/settings.php:768
 msgid "Article"
 msgstr "Artikel"
 
-#: includes/admin/settings.php:780
+#: includes/admin/settings.php:786
 msgid "Last status change"
 msgstr "Laatste statuswijziging"
 
-#: includes/admin/settings.php:787 includes/admin/settings.php:803
+#: includes/admin/settings.php:793
+#: includes/admin/settings.php:809
 msgid "Babbel ID"
 msgstr "Babbel ID"
 
-#: includes/admin/settings.php:799 zw-knabbel-wp.php:693
+#: includes/admin/settings.php:805
+#: zw-knabbel-wp.php:693
 msgid "Story is being processed..."
 msgstr "Verhaal wordt verwerkt..."
 
-#: includes/admin/settings.php:823
+#: includes/admin/settings.php:829
 msgid "Occurred"
 msgstr "Opgetreden"
 
-#: includes/admin/settings.php:839
+#: includes/admin/settings.php:845
 msgid "Retry"
 msgstr "Opnieuw verzenden"
 
-#: includes/admin/settings.php:844
+#: includes/admin/settings.php:850
 msgid "Refresh"
 msgstr "Vernieuwen"
 
-#: includes/babbel-api.php:60 includes/babbel-api.php:343
+#: includes/babbel-api.php:60
+#: includes/babbel-api.php:343
 msgid "Username and password are required"
 msgstr "Gebruikersnaam en wachtwoord zijn vereist"
 
-#: includes/babbel-api.php:94 includes/babbel-api.php:352
+#: includes/babbel-api.php:94
+#: includes/babbel-api.php:352
 msgid "Login failed: "
 msgstr "Inloggen mislukt: "
 
@@ -370,23 +364,29 @@ msgstr "Inloggen mislukt: "
 msgid "No session cookies received"
 msgstr "Geen sessiecookies ontvangen"
 
-#: includes/babbel-api.php:200 includes/babbel-api.php:206
+#: includes/babbel-api.php:200
+#: includes/babbel-api.php:206
 msgid "Could not encode story data"
 msgstr "Kon verhaalgegevens niet coderen"
 
-#: includes/babbel-api.php:231 includes/babbel-api.php:452
-#: includes/babbel-api.php:527 includes/babbel-api.php:626
+#: includes/babbel-api.php:231
+#: includes/babbel-api.php:452
+#: includes/babbel-api.php:527
+#: includes/babbel-api.php:626
 msgid "API connection failed: "
 msgstr "API-verbinding mislukt: "
 
 #. translators: %1$d is the HTTP status code, %2$s is the response body.
-#: includes/babbel-api.php:253 includes/babbel-api.php:474
-#: includes/babbel-api.php:550 includes/babbel-api.php:648
+#: includes/babbel-api.php:253
+#: includes/babbel-api.php:474
+#: includes/babbel-api.php:550
+#: includes/babbel-api.php:648
 #, php-format
 msgid "API error: HTTP %1$d - %2$s"
 msgstr "API-fout: HTTP %1$d - %2$s"
 
-#: includes/babbel-api.php:272 includes/babbel-api.php:741
+#: includes/babbel-api.php:272
+#: includes/babbel-api.php:741
 msgid "Invalid API response"
 msgstr "Ongeldige API-respons"
 
@@ -398,7 +398,8 @@ msgstr "API-fout"
 msgid "No story ID received from API"
 msgstr "Geen verhaal-ID ontvangen van API"
 
-#: includes/babbel-api.php:325 zw-knabbel-wp.php:748
+#: includes/babbel-api.php:325
+#: zw-knabbel-wp.php:748
 msgid "Story created successfully"
 msgstr "Verhaal succesvol aangemaakt"
 
@@ -426,7 +427,8 @@ msgstr "Onverwachte respons: HTTP %d"
 msgid "No data to update"
 msgstr "Geen gegevens om bij te werken"
 
-#: includes/babbel-api.php:420 includes/babbel-api.php:426
+#: includes/babbel-api.php:420
+#: includes/babbel-api.php:426
 msgid "Could not encode update data"
 msgstr "Kon updategegevens niet coderen"
 
@@ -438,7 +440,8 @@ msgstr "Verhaal succesvol bijgewerkt"
 msgid "Story deleted successfully"
 msgstr "Verhaal succesvol verwijderd"
 
-#: includes/babbel-api.php:594 includes/babbel-api.php:600
+#: includes/babbel-api.php:594
+#: includes/babbel-api.php:600
 msgid "Could not encode restore data"
 msgstr "Kon herstelgegevens niet coderen"
 
@@ -476,7 +479,8 @@ msgstr "Verhaal bijgewerkt (bericht gepubliceerd)"
 msgid "Story updated in Babbel"
 msgstr "Verhaal bijgewerkt in Babbel"
 
-#: includes/post-hooks.php:214 includes/post-hooks.php:234
+#: includes/post-hooks.php:214
+#: includes/post-hooks.php:234
 msgid "Story restored in Babbel"
 msgstr "Verhaal hersteld in Babbel"
 

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-11T14:51:44+00:00\n"
+"POT-Creation-Date: 2026-08-11T15:02:14+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zw-knabbel-wp\n"
@@ -17,7 +17,7 @@ msgstr ""
 #. Plugin Name of the plugin
 #: zw-knabbel-wp.php
 #: includes/admin/settings.php:66
-#: includes/admin/settings.php:229
+#: includes/admin/settings.php:235
 msgid "ZuidWest Knabbel"
 msgstr ""
 
@@ -55,28 +55,28 @@ msgid "Babbel sync warning"
 msgstr ""
 
 #: includes/admin/metabox.php:137
-#: includes/admin/settings.php:592
-#: includes/admin/settings.php:771
+#: includes/admin/settings.php:598
+#: includes/admin/settings.php:777
 msgid "Status"
 msgstr ""
 
 #: includes/admin/metabox.php:141
-#: includes/admin/settings.php:715
+#: includes/admin/settings.php:721
 msgid "Scheduled"
 msgstr ""
 
 #: includes/admin/metabox.php:142
-#: includes/admin/settings.php:716
+#: includes/admin/settings.php:722
 msgid "Processing"
 msgstr ""
 
 #: includes/admin/metabox.php:143
-#: includes/admin/settings.php:717
+#: includes/admin/settings.php:723
 msgid "Sent"
 msgstr ""
 
 #: includes/admin/metabox.php:144
-#: includes/admin/settings.php:718
+#: includes/admin/settings.php:724
 msgid "Error"
 msgstr ""
 
@@ -101,19 +101,19 @@ msgid "Scheduled:"
 msgstr ""
 
 #: includes/admin/metabox.php:178
-#: includes/admin/settings.php:809
+#: includes/admin/settings.php:815
 msgid "Last sync error"
 msgstr ""
 
 #: includes/admin/metabox.php:184
-#: includes/admin/settings.php:814
+#: includes/admin/settings.php:820
 msgid "Operation"
 msgstr ""
 
 #: includes/admin/metabox.php:202
-#: includes/admin/settings.php:298
-#: includes/admin/settings.php:793
-#: includes/admin/settings.php:798
+#: includes/admin/settings.php:304
+#: includes/admin/settings.php:799
+#: includes/admin/settings.php:804
 msgid "Message"
 msgstr ""
 
@@ -125,230 +125,230 @@ msgstr ""
 msgid "ZuidWest Knabbel Settings"
 msgstr ""
 
-#: includes/admin/settings.php:180
+#: includes/admin/settings.php:186
 msgid "You do not have sufficient permissions to view this page."
 msgstr ""
 
-#: includes/admin/settings.php:205
+#: includes/admin/settings.php:211
 msgid "Testing..."
 msgstr ""
 
-#: includes/admin/settings.php:206
-#: includes/admin/settings.php:441
+#: includes/admin/settings.php:212
+#: includes/admin/settings.php:447
 msgid "Test API Connection"
 msgstr ""
 
-#: includes/admin/settings.php:207
+#: includes/admin/settings.php:213
 msgid "An error occurred"
 msgstr ""
 
-#: includes/admin/settings.php:220
+#: includes/admin/settings.php:226
 msgid "Recent errors cleared."
 msgstr ""
 
-#: includes/admin/settings.php:224
+#: includes/admin/settings.php:230
 msgid "Recent errors could not be cleared. Please try again."
 msgstr ""
 
-#: includes/admin/settings.php:231
+#: includes/admin/settings.php:237
 msgid "Wijzigingen opslaan"
 msgstr ""
 
-#: includes/admin/settings.php:289
+#: includes/admin/settings.php:295
 msgid "Recent Errors"
 msgstr ""
 
-#: includes/admin/settings.php:296
+#: includes/admin/settings.php:302
 msgid "Time"
 msgstr ""
 
-#: includes/admin/settings.php:297
+#: includes/admin/settings.php:303
 msgid "Component"
 msgstr ""
 
-#: includes/admin/settings.php:304
+#: includes/admin/settings.php:310
 msgid "No valid recent errors to display."
 msgstr ""
 
-#: includes/admin/settings.php:335
+#: includes/admin/settings.php:341
 msgid "Clear Errors"
 msgstr ""
 
-#: includes/admin/settings.php:376
+#: includes/admin/settings.php:382
 msgid "Babbel API"
 msgstr ""
 
-#: includes/admin/settings.php:380
+#: includes/admin/settings.php:386
 msgid "Configure the Babbel API settings."
 msgstr ""
 
-#: includes/admin/settings.php:385
+#: includes/admin/settings.php:391
 msgid "Babbel API Base URL"
 msgstr ""
 
-#: includes/admin/settings.php:394
+#: includes/admin/settings.php:400
 msgid "The base URL of the Babbel API (without trailing slash)."
 msgstr ""
 
-#: includes/admin/settings.php:401
+#: includes/admin/settings.php:407
 msgid "Babbel API Username"
 msgstr ""
 
-#: includes/admin/settings.php:408
+#: includes/admin/settings.php:414
 msgid "username"
 msgstr ""
 
-#: includes/admin/settings.php:413
+#: includes/admin/settings.php:419
 msgid "Babbel API Password"
 msgstr ""
 
-#: includes/admin/settings.php:431
+#: includes/admin/settings.php:437
 msgid "Enable Debug Mode"
 msgstr ""
 
-#: includes/admin/settings.php:435
+#: includes/admin/settings.php:441
 msgid "Show debug information and status in the sidebar. Only enable for troubleshooting."
 msgstr ""
 
-#: includes/admin/settings.php:462
+#: includes/admin/settings.php:468
 msgid "AI Generation"
 msgstr ""
 
-#: includes/admin/settings.php:466
+#: includes/admin/settings.php:472
 msgid "WordPress selects a suitable model from your configured AI providers."
 msgstr ""
 
-#: includes/admin/settings.php:468
+#: includes/admin/settings.php:474
 msgid "Manage AI providers"
 msgstr ""
 
-#: includes/admin/settings.php:475
+#: includes/admin/settings.php:481
 msgid "AI Model"
 msgstr ""
 
-#: includes/admin/settings.php:478
+#: includes/admin/settings.php:484
 msgid "Automatic"
 msgstr ""
 
-#: includes/admin/settings.php:491
+#: includes/admin/settings.php:496
 msgid "Choose a configured text model, or let WordPress select one automatically."
 msgstr ""
 
-#: includes/admin/settings.php:497
+#: includes/admin/settings.php:503
 msgid "No configured text generation models are available."
 msgstr ""
 
-#: includes/admin/settings.php:503
+#: includes/admin/settings.php:509
 msgid "Speech Text Generation Prompt"
 msgstr ""
 
-#: includes/admin/settings.php:511
+#: includes/admin/settings.php:517
 msgid "Prompt for converting to radio-friendly speech text. Leave empty for default prompt."
 msgstr ""
 
-#: includes/admin/settings.php:517
+#: includes/admin/settings.php:523
 msgid "Few-shot Examples"
 msgstr ""
 
-#: includes/admin/settings.php:528
+#: includes/admin/settings.php:534
 msgid "Number of editor-corrected examples to include in the speech prompt (0 to disable, max 20). Synced nightly from Babbel."
 msgstr ""
 
-#: includes/admin/settings.php:548
+#: includes/admin/settings.php:554
 msgid "Sun"
 msgstr ""
 
-#: includes/admin/settings.php:549
+#: includes/admin/settings.php:555
 msgid "Mon"
 msgstr ""
 
-#: includes/admin/settings.php:550
+#: includes/admin/settings.php:556
 msgid "Tue"
 msgstr ""
 
-#: includes/admin/settings.php:551
+#: includes/admin/settings.php:557
 msgid "Wed"
 msgstr ""
 
-#: includes/admin/settings.php:552
+#: includes/admin/settings.php:558
 msgid "Thu"
 msgstr ""
 
-#: includes/admin/settings.php:553
+#: includes/admin/settings.php:559
 msgid "Fri"
 msgstr ""
 
-#: includes/admin/settings.php:554
+#: includes/admin/settings.php:560
 msgid "Sat"
 msgstr ""
 
-#: includes/admin/settings.php:561
+#: includes/admin/settings.php:567
 msgid "Story Defaults"
 msgstr ""
 
-#: includes/admin/settings.php:566
+#: includes/admin/settings.php:572
 msgid "Start Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:574
+#: includes/admin/settings.php:580
 msgid "Number of days from publication for start date."
 msgstr ""
 
-#: includes/admin/settings.php:579
+#: includes/admin/settings.php:585
 msgid "End Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:587
+#: includes/admin/settings.php:593
 msgid "Number of days from publication for end date."
 msgstr ""
 
-#: includes/admin/settings.php:601
+#: includes/admin/settings.php:607
 msgid "Active"
 msgstr ""
 
-#: includes/admin/settings.php:606
+#: includes/admin/settings.php:612
 msgid "Days"
 msgstr ""
 
-#: includes/admin/settings.php:624
+#: includes/admin/settings.php:630
 msgid "Which days the story may be broadcast."
 msgstr ""
 
-#: includes/admin/settings.php:742
+#: includes/admin/settings.php:748
 msgid "Knabbel Story Debug Overview"
 msgstr ""
 
-#: includes/admin/settings.php:756
+#: includes/admin/settings.php:762
 msgid "Show"
 msgstr ""
 
-#: includes/admin/settings.php:762
+#: includes/admin/settings.php:768
 msgid "Article"
 msgstr ""
 
-#: includes/admin/settings.php:780
+#: includes/admin/settings.php:786
 msgid "Last status change"
 msgstr ""
 
-#: includes/admin/settings.php:787
-#: includes/admin/settings.php:803
+#: includes/admin/settings.php:793
+#: includes/admin/settings.php:809
 msgid "Babbel ID"
 msgstr ""
 
-#: includes/admin/settings.php:799
+#: includes/admin/settings.php:805
 #: zw-knabbel-wp.php:693
 msgid "Story is being processed..."
 msgstr ""
 
-#: includes/admin/settings.php:823
+#: includes/admin/settings.php:829
 msgid "Occurred"
 msgstr ""
 
-#: includes/admin/settings.php:839
+#: includes/admin/settings.php:845
 msgid "Retry"
 msgstr ""
 
-#: includes/admin/settings.php:844
+#: includes/admin/settings.php:850
 msgid "Refresh"
 msgstr ""
 

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-26T21:56:40+00:00\n"
+"POT-Creation-Date: 2026-08-11T14:51:44+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zw-knabbel-wp\n"
@@ -17,7 +17,7 @@ msgstr ""
 #. Plugin Name of the plugin
 #: zw-knabbel-wp.php
 #: includes/admin/settings.php:66
-#: includes/admin/settings.php:228
+#: includes/admin/settings.php:229
 msgid "ZuidWest Knabbel"
 msgstr ""
 
@@ -41,79 +41,79 @@ msgstr ""
 msgid "https://www.zuidwesttv.nl"
 msgstr ""
 
-#: includes/admin/metabox.php:70
-#: includes/admin/metabox.php:115
+#: includes/admin/metabox.php:62
+#: includes/admin/metabox.php:107
 msgid "Radio News"
 msgstr ""
 
-#: includes/admin/metabox.php:90
+#: includes/admin/metabox.php:82
 msgid "Knabbel Status"
 msgstr ""
 
-#: includes/admin/metabox.php:121
+#: includes/admin/metabox.php:113
 msgid "Babbel sync warning"
 msgstr ""
 
-#: includes/admin/metabox.php:145
-#: includes/admin/settings.php:561
-#: includes/admin/settings.php:740
+#: includes/admin/metabox.php:137
+#: includes/admin/settings.php:592
+#: includes/admin/settings.php:771
 msgid "Status"
 msgstr ""
 
-#: includes/admin/metabox.php:149
-#: includes/admin/settings.php:684
+#: includes/admin/metabox.php:141
+#: includes/admin/settings.php:715
 msgid "Scheduled"
 msgstr ""
 
-#: includes/admin/metabox.php:150
-#: includes/admin/settings.php:685
+#: includes/admin/metabox.php:142
+#: includes/admin/settings.php:716
 msgid "Processing"
 msgstr ""
 
-#: includes/admin/metabox.php:151
-#: includes/admin/settings.php:686
+#: includes/admin/metabox.php:143
+#: includes/admin/settings.php:717
 msgid "Sent"
 msgstr ""
 
-#: includes/admin/metabox.php:152
-#: includes/admin/settings.php:687
+#: includes/admin/metabox.php:144
+#: includes/admin/settings.php:718
 msgid "Error"
 msgstr ""
 
-#: includes/admin/metabox.php:153
+#: includes/admin/metabox.php:145
 msgid "Deleted"
 msgstr ""
 
-#: includes/admin/metabox.php:155
+#: includes/admin/metabox.php:147
 msgid "—"
 msgstr ""
 
-#: includes/admin/metabox.php:161
+#: includes/admin/metabox.php:153
 msgid "Last status change:"
 msgstr ""
 
-#: includes/admin/metabox.php:171
+#: includes/admin/metabox.php:163
 msgid "Story ID"
 msgstr ""
 
-#: includes/admin/metabox.php:177
+#: includes/admin/metabox.php:169
 msgid "Scheduled:"
 msgstr ""
 
-#: includes/admin/metabox.php:186
-#: includes/admin/settings.php:778
+#: includes/admin/metabox.php:178
+#: includes/admin/settings.php:809
 msgid "Last sync error"
 msgstr ""
 
-#: includes/admin/metabox.php:192
-#: includes/admin/settings.php:783
+#: includes/admin/metabox.php:184
+#: includes/admin/settings.php:814
 msgid "Operation"
 msgstr ""
 
-#: includes/admin/metabox.php:210
-#: includes/admin/settings.php:297
-#: includes/admin/settings.php:762
-#: includes/admin/settings.php:767
+#: includes/admin/metabox.php:202
+#: includes/admin/settings.php:298
+#: includes/admin/settings.php:793
+#: includes/admin/settings.php:798
 msgid "Message"
 msgstr ""
 
@@ -125,214 +125,230 @@ msgstr ""
 msgid "ZuidWest Knabbel Settings"
 msgstr ""
 
-#: includes/admin/settings.php:179
+#: includes/admin/settings.php:180
 msgid "You do not have sufficient permissions to view this page."
 msgstr ""
 
-#: includes/admin/settings.php:204
+#: includes/admin/settings.php:205
 msgid "Testing..."
 msgstr ""
 
-#: includes/admin/settings.php:205
-#: includes/admin/settings.php:440
+#: includes/admin/settings.php:206
+#: includes/admin/settings.php:441
 msgid "Test API Connection"
 msgstr ""
 
-#: includes/admin/settings.php:206
+#: includes/admin/settings.php:207
 msgid "An error occurred"
 msgstr ""
 
-#: includes/admin/settings.php:219
+#: includes/admin/settings.php:220
 msgid "Recent errors cleared."
 msgstr ""
 
-#: includes/admin/settings.php:223
+#: includes/admin/settings.php:224
 msgid "Recent errors could not be cleared. Please try again."
 msgstr ""
 
-#: includes/admin/settings.php:230
+#: includes/admin/settings.php:231
 msgid "Wijzigingen opslaan"
 msgstr ""
 
-#: includes/admin/settings.php:288
+#: includes/admin/settings.php:289
 msgid "Recent Errors"
 msgstr ""
 
-#: includes/admin/settings.php:295
+#: includes/admin/settings.php:296
 msgid "Time"
 msgstr ""
 
-#: includes/admin/settings.php:296
+#: includes/admin/settings.php:297
 msgid "Component"
 msgstr ""
 
-#: includes/admin/settings.php:303
+#: includes/admin/settings.php:304
 msgid "No valid recent errors to display."
 msgstr ""
 
-#: includes/admin/settings.php:334
+#: includes/admin/settings.php:335
 msgid "Clear Errors"
 msgstr ""
 
-#: includes/admin/settings.php:375
+#: includes/admin/settings.php:376
 msgid "Babbel API"
 msgstr ""
 
-#: includes/admin/settings.php:379
+#: includes/admin/settings.php:380
 msgid "Configure the Babbel API settings."
 msgstr ""
 
-#: includes/admin/settings.php:384
+#: includes/admin/settings.php:385
 msgid "Babbel API Base URL"
 msgstr ""
 
-#: includes/admin/settings.php:393
+#: includes/admin/settings.php:394
 msgid "The base URL of the Babbel API (without trailing slash)."
 msgstr ""
 
-#: includes/admin/settings.php:400
+#: includes/admin/settings.php:401
 msgid "Babbel API Username"
 msgstr ""
 
-#: includes/admin/settings.php:407
+#: includes/admin/settings.php:408
 msgid "username"
 msgstr ""
 
-#: includes/admin/settings.php:412
+#: includes/admin/settings.php:413
 msgid "Babbel API Password"
 msgstr ""
 
-#: includes/admin/settings.php:430
+#: includes/admin/settings.php:431
 msgid "Enable Debug Mode"
 msgstr ""
 
-#: includes/admin/settings.php:434
+#: includes/admin/settings.php:435
 msgid "Show debug information and status in the sidebar. Only enable for troubleshooting."
 msgstr ""
 
-#: includes/admin/settings.php:460
+#: includes/admin/settings.php:462
 msgid "AI Generation"
 msgstr ""
 
-#: includes/admin/settings.php:464
+#: includes/admin/settings.php:466
 msgid "WordPress selects a suitable model from your configured AI providers."
 msgstr ""
 
-#: includes/admin/settings.php:466
+#: includes/admin/settings.php:468
 msgid "Manage AI providers"
 msgstr ""
 
-#: includes/admin/settings.php:472
-msgid "Speech Text Generation Prompt"
+#: includes/admin/settings.php:475
+msgid "AI Model"
 msgstr ""
 
-#: includes/admin/settings.php:480
-msgid "Prompt for converting to radio-friendly speech text. Leave empty for default prompt."
+#: includes/admin/settings.php:478
+msgid "Automatic"
 msgstr ""
 
-#: includes/admin/settings.php:486
-msgid "Few-shot Examples"
+#: includes/admin/settings.php:491
+msgid "Choose a configured text model, or let WordPress select one automatically."
 msgstr ""
 
 #: includes/admin/settings.php:497
-msgid "Number of editor-corrected examples to include in the speech prompt (0 to disable, max 20). Synced nightly from Babbel."
+msgid "No configured text generation models are available."
+msgstr ""
+
+#: includes/admin/settings.php:503
+msgid "Speech Text Generation Prompt"
+msgstr ""
+
+#: includes/admin/settings.php:511
+msgid "Prompt for converting to radio-friendly speech text. Leave empty for default prompt."
 msgstr ""
 
 #: includes/admin/settings.php:517
-msgid "Sun"
+msgid "Few-shot Examples"
 msgstr ""
 
-#: includes/admin/settings.php:518
-msgid "Mon"
-msgstr ""
-
-#: includes/admin/settings.php:519
-msgid "Tue"
-msgstr ""
-
-#: includes/admin/settings.php:520
-msgid "Wed"
-msgstr ""
-
-#: includes/admin/settings.php:521
-msgid "Thu"
-msgstr ""
-
-#: includes/admin/settings.php:522
-msgid "Fri"
-msgstr ""
-
-#: includes/admin/settings.php:523
-msgid "Sat"
-msgstr ""
-
-#: includes/admin/settings.php:530
-msgid "Story Defaults"
-msgstr ""
-
-#: includes/admin/settings.php:535
-msgid "Start Date (days from now)"
-msgstr ""
-
-#: includes/admin/settings.php:543
-msgid "Number of days from publication for start date."
+#: includes/admin/settings.php:528
+msgid "Number of editor-corrected examples to include in the speech prompt (0 to disable, max 20). Synced nightly from Babbel."
 msgstr ""
 
 #: includes/admin/settings.php:548
+msgid "Sun"
+msgstr ""
+
+#: includes/admin/settings.php:549
+msgid "Mon"
+msgstr ""
+
+#: includes/admin/settings.php:550
+msgid "Tue"
+msgstr ""
+
+#: includes/admin/settings.php:551
+msgid "Wed"
+msgstr ""
+
+#: includes/admin/settings.php:552
+msgid "Thu"
+msgstr ""
+
+#: includes/admin/settings.php:553
+msgid "Fri"
+msgstr ""
+
+#: includes/admin/settings.php:554
+msgid "Sat"
+msgstr ""
+
+#: includes/admin/settings.php:561
+msgid "Story Defaults"
+msgstr ""
+
+#: includes/admin/settings.php:566
+msgid "Start Date (days from now)"
+msgstr ""
+
+#: includes/admin/settings.php:574
+msgid "Number of days from publication for start date."
+msgstr ""
+
+#: includes/admin/settings.php:579
 msgid "End Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:556
+#: includes/admin/settings.php:587
 msgid "Number of days from publication for end date."
 msgstr ""
 
-#: includes/admin/settings.php:570
+#: includes/admin/settings.php:601
 msgid "Active"
 msgstr ""
 
-#: includes/admin/settings.php:575
+#: includes/admin/settings.php:606
 msgid "Days"
 msgstr ""
 
-#: includes/admin/settings.php:593
+#: includes/admin/settings.php:624
 msgid "Which days the story may be broadcast."
 msgstr ""
 
-#: includes/admin/settings.php:711
+#: includes/admin/settings.php:742
 msgid "Knabbel Story Debug Overview"
 msgstr ""
 
-#: includes/admin/settings.php:725
+#: includes/admin/settings.php:756
 msgid "Show"
 msgstr ""
 
-#: includes/admin/settings.php:731
+#: includes/admin/settings.php:762
 msgid "Article"
 msgstr ""
 
-#: includes/admin/settings.php:749
+#: includes/admin/settings.php:780
 msgid "Last status change"
 msgstr ""
 
-#: includes/admin/settings.php:756
-#: includes/admin/settings.php:772
+#: includes/admin/settings.php:787
+#: includes/admin/settings.php:803
 msgid "Babbel ID"
 msgstr ""
 
-#: includes/admin/settings.php:768
-#: zw-knabbel-wp.php:691
+#: includes/admin/settings.php:799
+#: zw-knabbel-wp.php:693
 msgid "Story is being processed..."
 msgstr ""
 
-#: includes/admin/settings.php:792
+#: includes/admin/settings.php:823
 msgid "Occurred"
 msgstr ""
 
-#: includes/admin/settings.php:808
+#: includes/admin/settings.php:839
 msgid "Retry"
 msgstr ""
 
-#: includes/admin/settings.php:813
+#: includes/admin/settings.php:844
 msgid "Refresh"
 msgstr ""
 
@@ -385,7 +401,7 @@ msgid "No story ID received from API"
 msgstr ""
 
 #: includes/babbel-api.php:325
-#: zw-knabbel-wp.php:746
+#: zw-knabbel-wp.php:748
 msgid "Story created successfully"
 msgstr ""
 
@@ -445,59 +461,59 @@ msgstr ""
 msgid "API error: HTTP %d"
 msgstr ""
 
-#: includes/post-hooks.php:210
+#: includes/post-hooks.php:113
 msgid "Story deleted from Babbel"
 msgstr ""
 
-#: includes/post-hooks.php:300
-msgid "Story updated (post published)"
-msgstr ""
-
-#: includes/post-hooks.php:335
-msgid "Story updated in Babbel"
-msgstr ""
-
-#: includes/post-hooks.php:354
-msgid "Story deleted (post unscheduled)"
-msgstr ""
-
-#: includes/post-hooks.php:385
+#: includes/post-hooks.php:116
 msgid "Story deleted (post trashed)"
 msgstr ""
 
-#: includes/post-hooks.php:450
-#: includes/post-hooks.php:470
+#: includes/post-hooks.php:119
+msgid "Story deleted (post unscheduled)"
+msgstr ""
+
+#: includes/post-hooks.php:162
+msgid "Story updated (post published)"
+msgstr ""
+
+#: includes/post-hooks.php:175
+msgid "Story updated in Babbel"
+msgstr ""
+
+#: includes/post-hooks.php:214
+#: includes/post-hooks.php:234
 msgid "Story restored in Babbel"
 msgstr ""
 
-#: includes/post-hooks.php:640
+#: includes/post-hooks.php:404
 msgid "Processing already scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:659
+#: includes/post-hooks.php:423
 msgid "Processing scheduled"
 msgstr ""
 
-#: includes/post-hooks.php:667
+#: includes/post-hooks.php:431
 msgid "Could not schedule action"
 msgstr ""
 
-#: zw-knabbel-wp.php:616
+#: zw-knabbel-wp.php:618
 msgid "Insufficient permissions"
 msgstr ""
 
-#: zw-knabbel-wp.php:655
+#: zw-knabbel-wp.php:657
 msgid "Already sent — skipping"
 msgstr ""
 
-#: zw-knabbel-wp.php:667
+#: zw-knabbel-wp.php:669
 msgid "Post not found"
 msgstr ""
 
-#: zw-knabbel-wp.php:680
+#: zw-knabbel-wp.php:682
 msgid "Send to Babbel is disabled for this post"
 msgstr ""
 
-#: zw-knabbel-wp.php:707
+#: zw-knabbel-wp.php:709
 msgid "Could not generate speech text"
 msgstr ""

--- a/tests/e2e/mu-plugins/knabbel-ai-client-stub.php
+++ b/tests/e2e/mu-plugins/knabbel-ai-client-stub.php
@@ -20,7 +20,12 @@ add_filter(
 	'pre_http_request',
 	static function ( false|array|WP_Error $preempt, array $parsed_args, string $url ): false|array|WP_Error {
 		if ( 'https://api.openai.com/v1/models' === $url ) {
-			$body = array( 'data' => array( array( 'id' => 'gpt-4.1-mini' ) ) );
+			$body = array(
+				'data' => array(
+					array( 'id' => 'gpt-4.1-mini' ),
+					array( 'id' => 'gpt-4.1' ),
+				),
+			);
 		} elseif ( 'https://api.openai.com/v1/responses' === $url ) {
 			$headers = $parsed_args['headers'] ?? array();
 			if ( ! is_array( $headers ) || 'Bearer e2e-openai-key' !== ( array_change_key_case( $headers, CASE_LOWER )['authorization'] ?? '' ) ) {

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -123,6 +123,7 @@ final class Knabbel_E2E_Suite {
 				'api_base_url'      => self::BABBEL_BASE_URL,
 				'api_username'      => 'admin',
 				'api_password'      => $password,
+				'ai_model'          => 'openai/gpt-4.1',
 				'start_days_offset' => 1,
 				'end_days_offset'   => 2,
 				'default_status'    => 'draft',
@@ -214,6 +215,7 @@ final class Knabbel_E2E_Suite {
 		$this->assert_true( is_array( $ai_request ), 'The native AI provider request must be observable.' );
 		$this->assert_same( 1000, $ai_request['max_output_tokens'] ?? null, 'The native AI request must retain the output token limit.' );
 		$this->assert_same( 0.7, $ai_request['temperature'] ?? null, 'The native AI request must retain the configured temperature.' );
+		$this->assert_same( 'gpt-4.1', $ai_request['model'] ?? null, 'The native AI request must use the configured model preference.' );
 		$request_input = (string) wp_json_encode( $ai_request['input'] ?? array() );
 		$this->assert_string_contains( $example_input, $request_input, 'The native AI request must include the few-shot user example.' );
 		$this->assert_string_contains( $example_output, $request_input, 'The native AI request must include the few-shot model example.' );

--- a/tests/playwright/editor-flow.spec.ts
+++ b/tests/playwright/editor-flow.spec.ts
@@ -53,6 +53,7 @@ test.describe
                     .locator(`[name="knabbel_settings[${key}]"]`)
                     .fill(value);
             }
+            await page.getByLabel('AI Model').selectOption('openai/gpt-4.1');
 
             const debugMode = page.locator(
                 '[name="knabbel_settings[debug_mode]"]',
@@ -76,6 +77,9 @@ test.describe
             await expect(
                 page.getByRole('link', { name: 'Manage AI providers' }),
             ).toHaveAttribute('href', /options-connectors\.php$/);
+            await expect(page.getByLabel('AI Model')).toHaveValue(
+                'openai/gpt-4.1',
+            );
             await expect(
                 page.getByLabel('Speech Text Generation Prompt'),
             ).toBeVisible();

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -540,6 +540,7 @@ function activate(): void {
 			'api_base_url'      => 'https://babbel.example.com/api/v1',
 			'api_username'      => '',
 			'api_password'      => '',
+			'ai_model'          => '',
 			'speech_prompt'     => '',
 			'debug_mode'        => false,
 			// Story defaults.


### PR DESCRIPTION
## Summary

- list configured text-generation models from the WordPress AI Client registry
- add an Automatic/model selector to the Knabbel settings page
- apply the stored provider/model preference to generated speech requests
- add Dutch translations and end-to-end coverage for persistence and request routing

## Testing

- vendor/bin/phpcs
- composer phpstan
- npm run lint
- msgfmt --check languages/zw-knabbel-wp-nl_NL.po
- BABBEL_PATH=/Users/rmens/Documents/GitHub/zwfm-babbel tests/e2e/run.sh (7 browser tests; 18 integration scenarios, 253 assertions)