### PR TITLE
refactor(settings): extract shared default_settings() helper

### DIFF
--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -139,14 +139,13 @@ function sanitize_settings( array $input ): array {
 			: 'draft';
 	}
 
-	// Boolean/checkbox fields.
-	$sanitized['debug_mode'] = ! empty( $input['debug_mode'] ) ? 1 : 0;
+	// Boolean/checkbox fields, stored as real booleans to match default_settings().
+	$sanitized['debug_mode'] = ! empty( $input['debug_mode'] );
 
 	// Weekday checkboxes.
-	$weekdays = array( 'sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday' );
-	foreach ( $weekdays as $day ) {
+	foreach ( array_keys( WEEKDAY_MAP ) as $day ) {
 		$field_name               = 'weekday_' . $day;
-		$sanitized[ $field_name ] = ! empty( $input[ $field_name ] ) ? 1 : 0;
+		$sanitized[ $field_name ] = ! empty( $input[ $field_name ] );
 	}
 
 	return $sanitized;
@@ -190,7 +189,7 @@ function settings_page(): void {
 		)
 	);
 
-	$settings = get_option( 'knabbel_settings', array() );
+	$settings = get_plugin_settings();
 	?>
 	<div class="wrap knabbel-wp-admin">
 		<?php
@@ -370,8 +369,8 @@ function render_babbel_api_card( array $settings ): void {
 				<input type="text"
 					name="knabbel_settings[api_base_url]"
 					class="knabbel-field-input"
-					value="<?php echo esc_attr( $settings['api_base_url'] ?? '' ); ?>"
-					placeholder="https://api.example.com" />
+					value="<?php echo esc_attr( $settings['api_base_url'] ); ?>"
+					placeholder="https://babbel.example.com/api/v1" />
 				<p class="knabbel-field-description">
 					<?php esc_html_e( 'The base URL of the Babbel API (without trailing slash).', 'zw-knabbel-wp' ); ?>
 				</p>
@@ -386,7 +385,7 @@ function render_babbel_api_card( array $settings ): void {
 					<input type="text"
 						name="knabbel_settings[api_username]"
 						class="knabbel-field-input"
-						value="<?php echo esc_attr( $settings['api_username'] ?? '' ); ?>"
+						value="<?php echo esc_attr( $settings['api_username'] ); ?>"
 						placeholder="<?php esc_attr_e( 'username', 'zw-knabbel-wp' ); ?>" />
 				</div>
 
@@ -398,7 +397,7 @@ function render_babbel_api_card( array $settings ): void {
 					<input type="password"
 						name="knabbel_settings[api_password]"
 						class="knabbel-field-input"
-						value="<?php echo esc_attr( $settings['api_password'] ?? '' ); ?>" />
+						value="<?php echo esc_attr( $settings['api_password'] ); ?>" />
 				</div>
 			</div>
 
@@ -458,7 +457,7 @@ function render_ai_card( array $settings ): void {
 					name="knabbel_settings[speech_prompt]"
 					class="knabbel-field-input"
 					rows="4"
-					placeholder="<?php echo esc_attr( AI_DEFAULT_INSTRUCTION ); ?>"><?php echo esc_textarea( $settings['speech_prompt'] ?? '' ); ?></textarea>
+					placeholder="<?php echo esc_attr( AI_DEFAULT_INSTRUCTION ); ?>"><?php echo esc_textarea( $settings['speech_prompt'] ); ?></textarea>
 				<p class="knabbel-field-description">
 					<?php esc_html_e( 'Prompt for converting to radio-friendly speech text. Leave empty for default prompt.', 'zw-knabbel-wp' ); ?>
 				</p>
@@ -472,7 +471,7 @@ function render_ai_card( array $settings ): void {
 					id="knabbel-few-shot-count"
 					name="knabbel_settings[few_shot_count]"
 					class="knabbel-field-input"
-					value="<?php echo esc_attr( (string) ( $settings['few_shot_count'] ?? 5 ) ); ?>"
+					value="<?php echo esc_attr( (string) $settings['few_shot_count'] ); ?>"
 					min="0"
 					max="20" />
 				<p class="knabbel-field-description">
@@ -505,7 +504,7 @@ function render_defaults_card( array $settings ): void {
 		'friday'    => __( 'Fri', 'zw-knabbel-wp' ),
 		'saturday'  => __( 'Sat', 'zw-knabbel-wp' ),
 	);
-	$is_active = ( $settings['default_status'] ?? 'draft' ) === 'active';
+	$is_active = 'active' === $settings['default_status'];
 	?>
 	<div class="knabbel-settings-card full-width">
 		<div class="knabbel-card-title">
@@ -521,7 +520,7 @@ function render_defaults_card( array $settings ): void {
 							<input type="number"
 								name="knabbel_settings[start_days_offset]"
 								class="knabbel-field-input"
-								value="<?php echo esc_attr( (string) ( $settings['start_days_offset'] ?? 1 ) ); ?>"
+								value="<?php echo esc_attr( (string) $settings['start_days_offset'] ); ?>"
 								min="0" />
 							<span class="input-suffix"><?php esc_html_e( 'Number of days from publication for start date.', 'zw-knabbel-wp' ); ?></span>
 						</div>
@@ -534,7 +533,7 @@ function render_defaults_card( array $settings ): void {
 							<input type="number"
 								name="knabbel_settings[end_days_offset]"
 								class="knabbel-field-input"
-								value="<?php echo esc_attr( (string) ( $settings['end_days_offset'] ?? 2 ) ); ?>"
+								value="<?php echo esc_attr( (string) $settings['end_days_offset'] ); ?>"
 								min="0" />
 							<span class="input-suffix"><?php esc_html_e( 'Number of days from publication for end date.', 'zw-knabbel-wp' ); ?></span>
 						</div>
@@ -561,7 +560,7 @@ function render_defaults_card( array $settings ): void {
 							<?php foreach ( $weekdays as $key => $label ) : ?>
 								<?php
 								$field_name = 'weekday_' . $key;
-								$checked    = ! isset( $settings[ $field_name ] ) || ! empty( $settings[ $field_name ] );
+								$checked    = ! empty( $settings[ $field_name ] );
 								?>
 								<label class="knabbel-weekday <?php echo $checked ? 'checked' : ''; ?>">
 									<input type="checkbox"

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -85,24 +85,7 @@ function settings_register_settings(): void {
 		array(
 			'type'              => 'array',
 			'sanitize_callback' => __NAMESPACE__ . '\\sanitize_settings',
-			'default'           => array(
-				'api_base_url'      => '',
-				'api_username'      => '',
-				'api_password'      => '',
-				'speech_prompt'     => '',
-				'debug_mode'        => false,
-				'start_days_offset' => 1,
-				'end_days_offset'   => 2,
-				'default_status'    => 'draft',
-				'weekday_sunday'    => true,
-				'weekday_monday'    => true,
-				'weekday_tuesday'   => true,
-				'weekday_wednesday' => true,
-				'weekday_thursday'  => true,
-				'weekday_friday'    => true,
-				'weekday_saturday'  => true,
-				'few_shot_count'    => 5,
-			),
+			'default'           => default_settings(),
 		)
 	);
 }

--- a/includes/ai-handler.php
+++ b/includes/ai-handler.php
@@ -32,14 +32,12 @@ const AI_ARTICLE_PROMPT      = "Artikel:\n\"\"\"\n%s\n\"\"\"";
  * @return string|null The generated content or null on failure.
  */
 function ai_generate_content( string $content ): ?string {
-	$options       = (array) get_option( 'knabbel_settings', array() );
-	$speech_prompt = $options['speech_prompt'] ?? '';
-	$instruction   = is_string( $speech_prompt ) && '' !== trim( $speech_prompt )
-		? $speech_prompt
-		: AI_DEFAULT_INSTRUCTION;
+	$options       = get_plugin_settings();
+	$speech_prompt = (string) $options['speech_prompt'];
+	$instruction   = '' !== trim( $speech_prompt ) ? $speech_prompt : AI_DEFAULT_INSTRUCTION;
 
 	$messages       = array();
-	$few_shot_count = (int) ( $options['few_shot_count'] ?? 5 );
+	$few_shot_count = (int) $options['few_shot_count'];
 	$examples       = get_option( 'knabbel_few_shot_examples', array() );
 	if ( $few_shot_count > 0 && is_array( $examples ) ) {
 		foreach ( array_slice( $examples, 0, $few_shot_count ) as $example ) {

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -25,11 +25,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @phpstan-return BabbelCredentials
  */
 function babbel_get_credentials(): array {
-	$options = get_option( 'knabbel_settings' );
+	$options = get_plugin_settings();
 	return array(
-		'base_url' => rtrim( (string) ( $options['api_base_url'] ?? '' ), '/' ),
-		'username' => (string) ( $options['api_username'] ?? '' ),
-		'password' => (string) ( $options['api_password'] ?? '' ),
+		'base_url' => rtrim( (string) $options['api_base_url'], '/' ),
+		'username' => (string) $options['api_username'],
+		'password' => (string) $options['api_password'],
 	);
 }
 

--- a/includes/few-shot-cache.php
+++ b/includes/few-shot-cache.php
@@ -66,8 +66,8 @@ function few_shot_unschedule_sync(): void {
  * @since 0.3.0
  */
 function sync_few_shot_examples(): void {
-	$options   = get_option( 'knabbel_settings' );
-	$max_count = (int) ( $options['few_shot_count'] ?? 5 );
+	$options   = get_plugin_settings();
+	$max_count = (int) $options['few_shot_count'];
 
 	if ( $max_count <= 0 ) {
 		log( 'info', 'FewShotCache', 'Few-shot examples disabled (count set to 0)' );

--- a/includes/weekdays.php
+++ b/includes/weekdays.php
@@ -53,8 +53,7 @@ function settings_to_weekdays_bitmask( array $options ): int {
 	foreach ( WEEKDAY_MAP as $day => $value ) {
 		$field_key = "weekday_{$day}";
 		// Default to enabled if not explicitly set.
-		$is_enabled = ! isset( $options[ $field_key ] ) || ! empty( $options[ $field_key ] );
-		if ( $is_enabled ) {
+		if ( ! isset( $options[ $field_key ] ) || ! empty( $options[ $field_key ] ) ) {
 			$bitmask |= $value;
 		}
 	}

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -59,8 +59,7 @@ register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\deactivate' );
  * @return bool True when debug mode is enabled, false otherwise.
  */
 function debug_enabled(): bool {
-	$options = get_option( 'knabbel_settings' );
-	return ! empty( $options['debug_mode'] );
+	return ! empty( get_plugin_settings()['debug_mode'] );
 }
 
 /**
@@ -469,9 +468,9 @@ function is_story_sync_error_renderable( ?array $sync_error ): bool {
  * @return array{start_date: string, end_date: string, weekdays: int} Story dates and weekdays bitmask.
  */
 function calculate_story_dates( string $base_date = 'now' ): array {
-	$options      = get_option( 'knabbel_settings' );
-	$start_offset = (int) ( $options['start_days_offset'] ?? 1 );
-	$end_offset   = (int) ( $options['end_days_offset'] ?? 2 );
+	$options      = get_plugin_settings();
+	$start_offset = (int) $options['start_days_offset'];
+	$end_offset   = (int) $options['end_days_offset'];
 
 	$tz   = wp_timezone();
 	$base = new \DateTimeImmutable( $base_date, $tz );
@@ -534,7 +533,7 @@ function admin_init(): void {
 /**
  * Returns the default values for the knabbel_settings option.
  *
- * Single source of truth for activate() and the register_setting() default.
+ * Single source of truth for the knabbel_settings defaults.
  *
  * @since 0.6.0
  * @return array<string, mixed> The default settings.
@@ -563,22 +562,28 @@ function default_settings(): array {
 }
 
 /**
+ * Returns the knabbel_settings option merged over the defaults.
+ *
+ * Guarantees every default key exists, so read sites need no per-key fallbacks.
+ *
+ * @since 0.6.0
+ * @return array<string, mixed> The plugin settings.
+ */
+function get_plugin_settings(): array {
+	return wp_parse_args( (array) get_option( 'knabbel_settings', array() ), default_settings() );
+}
+
+/**
  * Runs on plugin activation.
  *
- * Sets up default options and cleans legacy metadata.
+ * Creates the settings option and cleans legacy metadata.
  *
  * @since 0.1.0
  */
 function activate(): void {
-		// Seed an example base URL so the settings page shows the expected format.
-		$default_options = array_merge(
-			default_settings(),
-			array( 'api_base_url' => 'https://babbel.example.com/api/v1' )
-		);
-
 		// Explicitly set autoload to true since these settings are needed on every admin page load.
 		// WP 6.6+ changed the default autoload behavior from 'yes' to dynamic heuristics.
-		add_option( 'knabbel_settings', $default_options, '', true );
+		add_option( 'knabbel_settings', default_settings(), '', true );
 
 		// Cleanup all legacy data on activation.
 		cleanup_legacy_data();
@@ -613,6 +618,8 @@ function deactivate(): void {
  * @since 0.1.0
  */
 function cleanup_legacy_data(): void {
+	// Raw read on purpose: this rewrites the stored value, and reading through
+	// get_plugin_settings() would bake the merged defaults into the database.
 	$settings = get_option( 'knabbel_settings' );
 	if ( ! is_array( $settings ) ) {
 		return;
@@ -731,8 +738,8 @@ function process_story_async( int|array $post_id_or_args ): void {
 	}
 
 	// Prepare story data using configurable defaults.
-	$options        = get_option( 'knabbel_settings' );
-	$default_status = $options['default_status'] ?? 'draft';
+	$options        = get_plugin_settings();
+	$default_status = $options['default_status'];
 
 	// Calculate dates based on post status:
 	// - For scheduled posts (future): use the scheduled publish time (post_date).

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -532,6 +532,37 @@ function admin_init(): void {
 }
 
 /**
+ * Returns the default values for the knabbel_settings option.
+ *
+ * Single source of truth for activate() and the register_setting() default.
+ *
+ * @since 0.6.0
+ * @return array<string, mixed> The default settings.
+ */
+function default_settings(): array {
+	return array(
+		'api_base_url'      => '',
+		'api_username'      => '',
+		'api_password'      => '',
+		'speech_prompt'     => '',
+		'debug_mode'        => false,
+		// Story defaults.
+		'start_days_offset' => 1,
+		'end_days_offset'   => 2,
+		'default_status'    => 'draft',
+		'weekday_sunday'    => true,
+		'weekday_monday'    => true,
+		'weekday_tuesday'   => true,
+		'weekday_wednesday' => true,
+		'weekday_thursday'  => true,
+		'weekday_friday'    => true,
+		'weekday_saturday'  => true,
+		// Few-shot examples.
+		'few_shot_count'    => 5,
+	);
+}
+
+/**
  * Runs on plugin activation.
  *
  * Sets up default options and cleans legacy metadata.
@@ -539,25 +570,10 @@ function admin_init(): void {
  * @since 0.1.0
  */
 function activate(): void {
-		$default_options = array(
-			'api_base_url'      => 'https://babbel.example.com/api/v1',
-			'api_username'      => '',
-			'api_password'      => '',
-			'speech_prompt'     => '',
-			'debug_mode'        => false,
-			// Story defaults.
-			'start_days_offset' => 1,
-			'end_days_offset'   => 2,
-			'default_status'    => 'draft',
-			'weekday_sunday'    => true,
-			'weekday_monday'    => true,
-			'weekday_tuesday'   => true,
-			'weekday_wednesday' => true,
-			'weekday_thursday'  => true,
-			'weekday_friday'    => true,
-			'weekday_saturday'  => true,
-			// Few-shot examples.
-			'few_shot_count'    => 5,
+		// Seed an example base URL so the settings page shows the expected format.
+		$default_options = array_merge(
+			default_settings(),
+			array( 'api_base_url' => 'https://babbel.example.com/api/v1' )
 		);
 
 		// Explicitly set autoload to true since these settings are needed on every admin page load.


### PR DESCRIPTION
## Summary

The default values for the `knabbel_settings` option were maintained in two places: `activate()` in `zw-knabbel-wp.php` and the `register_setting()` `default` array in `includes/admin/settings.php`. Every new setting required a synchronized edit in both files, and a missed site failed silently.

This PR extracts a single `default_settings()` helper as the source of truth:

- The helper lives in the main plugin file so it is available during WP-CLI activation, where the admin includes (`includes/admin/settings.php`) are not loaded.
- `activate()` keeps seeding the example `api_base_url` (`https://babbel.example.com/api/v1`) by overriding that one key via `array_merge()`; the canonical default stays `''`.
- No behavior change.

## Note

`feat/ai-model-selection` (#55, if open) adds an `ai_model` key to both duplicated arrays; whichever PR merges second needs a trivial rebase moving that key into the helper.

## Checks

- `vendor/bin/phpcs` clean
- `vendor/bin/phpstan analyse` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when loading and saving plugin settings.
  * Checkbox and weekday settings now correctly reflect their enabled or disabled state.
  * Reduced unexpected behavior caused by missing or incomplete configuration values.

* **Improvements**
  * Centralized default settings provide more reliable configuration across content generation, scheduling, and integrations.
  * Activation now starts with a blank API base URL instead of an example value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->