### PR TITLE
docs: audit PHP comments

### DIFF
--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Admin metabox functionality
+ * Admin metabox integration for the post editor.
  *
  * Provides the post editor metabox UI for sending posts to the Babbel API.
  * This file is only loaded in admin context.
@@ -18,9 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Initialize admin-only metabox functionality.
- *
- * Registers hooks for the post editor UI. Must only be called in admin context.
+ * Registers the admin-only metabox hooks.
  *
  * @since 0.1.0
  */
@@ -32,7 +30,7 @@ function metabox_init(): void {
 }
 
 /**
- * Enqueue admin assets for post edit screens.
+ * Enqueues assets for post edit screens.
  *
  * @since 0.1.0
  *
@@ -52,7 +50,7 @@ function metabox_enqueue_assets( string $hook ): void {
 }
 
 /**
- * Adds the per-post status metabox when Debug Mode is enabled.
+ * Adds the per-post status metabox in Debug Mode.
  *
  * @since 0.1.0
  */
@@ -115,7 +113,7 @@ function submitbox_render( \WP_Post $post ): void {
 }
 
 /**
- * Displays the status metabox content (Debug Mode only).
+ * Displays status details in Debug Mode.
  *
  * @since 0.1.0
  *
@@ -206,7 +204,7 @@ function metabox_render_status( \WP_Post $post ): void {
 }
 
 /**
- * Saves metabox data.
+ * Saves the Radionieuws checkbox state.
  *
  * The post-meta and post-save hooks reconcile story state after WordPress has
  * persisted the checkbox and post status.

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Settings administration functionality
+ * Settings administration for Knabbel WP.
  *
  * Manages plugin settings page, field registration, sanitization, and validation.
  *
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Initialize settings functionality.
+ * Registers the settings administration hooks.
  *
  * @since 0.1.0
  */
@@ -28,7 +28,7 @@ function settings_init(): void {
 }
 
 /**
- * Clears the rolling recent error list for an authorized administrator.
+ * Clears recent errors for an administrator.
  *
  * @since 0.4.0
  */
@@ -56,7 +56,7 @@ function handle_clear_recent_errors(): void {
 }
 
 /**
- * Adds the admin menu page.
+ * Adds the plugin settings page.
  *
  * @since 0.1.0
  */
@@ -71,7 +71,7 @@ function settings_add_admin_menu(): void {
 }
 
 /**
- * Registers settings with WordPress Settings API.
+ * Registers the plugin settings.
  *
  * Only registers the settings group and sanitization callback.
  * Field rendering is handled manually in settings_page().
@@ -91,7 +91,7 @@ function settings_register_settings(): void {
 }
 
 /**
- * Sanitizes the settings array before saving to the database.
+ * Sanitizes settings before storage.
  *
  * @since 0.1.0
  * @param array<string, mixed> $input The raw input array from the form.
@@ -158,7 +158,7 @@ function sanitize_settings( array $input ): array {
 }
 
 /**
- * Outputs the admin settings page with card-based layout.
+ * Renders the card-based settings page.
  *
  * @since 0.1.0
  */
@@ -243,7 +243,7 @@ function settings_page(): void {
 }
 
 /**
- * Displays the rolling list of recent plugin errors.
+ * Displays the rolling list of recent errors.
  *
  * Only top-level fields are rendered. Stored context remains intentionally
  * hidden so nested API data can never become an unfiltered admin output path.
@@ -328,7 +328,7 @@ function render_recent_errors(): void {
 }
 
 /**
- * Normalizes a stored error entry into the safe render shape.
+ * Returns the safe shape of a stored error.
  *
  * @since 0.4.0
  * @param mixed $entry Raw entry from the knabbel_recent_errors option.
@@ -525,7 +525,7 @@ function render_ai_card( array $settings ): void {
 }
 
 /**
- * Displays the Story Defaults settings card.
+ * Displays the story defaults card.
  *
  * @since 0.1.05
  * @param array<string, mixed> $settings Current settings.
@@ -619,7 +619,7 @@ function render_defaults_card( array $settings ): void {
 }
 
 /**
- * Displays the Verzonden Artikelen overview card.
+ * Displays the Verzonden Artikelen card.
  *
  * @since 0.1.05
  */

--- a/includes/ai-handler.php
+++ b/includes/ai-handler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WordPress AI Client integration
+ * WordPress AI Client integration for speech-text generation.
  *
  * Handles provider-independent speech text generation through WordPress Core.
  *
@@ -28,7 +28,7 @@ const AI_DEFAULT_INSTRUCTION = "Transformeer naar natuurlijke radiospreektekst m
 const AI_ARTICLE_PROMPT      = "Artikel:\n\"\"\"\n%s\n\"\"\"";
 
 /**
- * Get configured AI models that support text generation.
+ * Returns configured text-generation models.
  *
  * Model keys are "provider/model" setting values as understood by ai_parse_model_setting().
  *
@@ -68,7 +68,7 @@ function ai_get_available_models(): array {
 }
 
 /**
- * Parse a "provider/model" ai_model setting value into a model preference tuple.
+ * Parses a provider and model preference.
  *
  * @since 0.6.0
  * @param mixed $value The stored setting value.
@@ -84,7 +84,7 @@ function ai_parse_model_setting( mixed $value ): ?array {
 }
 
 /**
- * Generate speech text through the WordPress AI Client.
+ * Generates speech text through the WordPress AI Client.
  *
  * @since 0.1.0
  * @param string $content The source content.

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Babbel API integration
+ * Babbel API integration for story synchronization.
  *
  * Handles authentication, session management, and API communication with the Babbel API.
  *
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Get Babbel API credentials from plugin settings.
+ * Returns the configured Babbel API credentials.
  *
  * @since 0.1.0
  * @return array{base_url: string, username: string, password: string} Array with base_url, username, and password.
@@ -34,7 +34,7 @@ function babbel_get_credentials(): array {
 }
 
 /**
- * Build the transient key that caches the session for the configured API instance.
+ * Builds the session transient key.
  *
  * @since 0.1.0
  * @param array{base_url: string, username: string, password: string}|null $credentials Optional credential snapshot.
@@ -48,7 +48,7 @@ function babbel_get_session_cache_key( ?array $credentials = null ): string {
 }
 
 /**
- * Get cached session cookies, creating new session if needed.
+ * Returns cached or newly created session cookies.
  *
  * @since 0.1.0
  * @return array<int, \WP_Http_Cookie>|\WP_Error Session cookies array or WP_Error on failure.
@@ -106,7 +106,7 @@ function babbel_get_session_cookies(): array|\WP_Error {
 }
 
 /**
- * Clear cached session cookies.
+ * Clears cached session cookies.
  *
  * @since 0.1.0
  */
@@ -115,7 +115,7 @@ function babbel_clear_session_cache(): void {
 }
 
 /**
- * Make an authenticated request to the Babbel API.
+ * Sends an authenticated Babbel request.
  * Automatically retries with fresh session on 401 Unauthorized.
  *
  * @since 0.1.0
@@ -163,7 +163,7 @@ function babbel_make_authenticated_request( string $url, array $args = array() )
 }
 
 /**
- * Create a story via the Babbel API.
+ * Creates a story through the Babbel API.
  *
  * @since 0.1.0
  * @param array<string, mixed> $story_data The story data to send.
@@ -328,7 +328,7 @@ function babbel_create_story( array $story_data ): array {
 
 
 /**
- * Test the connection to the Babbel API.
+ * Tests the Babbel API connection.
  * Authenticates and then verifies session by fetching current user info.
  *
  * @since 0.1.0
@@ -391,7 +391,7 @@ function babbel_test_connection(): array {
 }
 
 /**
- * Update an existing story in the Babbel API.
+ * Updates an existing Babbel story.
  *
  * @since 0.2.0
  * @param string                                                                        $story_id   The Babbel story ID.
@@ -492,7 +492,7 @@ function babbel_update_story( string $story_id, array $story_data ): array {
 }
 
 /**
- * Delete (soft delete) a story from the Babbel API.
+ * Soft-deletes a Babbel story.
  *
  * @since 0.2.0
  * @param string $story_id The Babbel story ID.
@@ -568,7 +568,7 @@ function babbel_delete_story( string $story_id ): array {
 }
 
 /**
- * Restore a soft-deleted story in the Babbel API.
+ * Restores a soft-deleted Babbel story.
  *
  * The PATCH endpoint only accepts 'status' and 'deleted_at' fields.
  * To update the title after restore, use babbel_update_story() separately.
@@ -666,7 +666,7 @@ function babbel_restore_story( string $story_id ): array {
 }
 
 /**
- * Fetch recent stories from the Babbel API for few-shot prompt examples.
+ * Returns recent stories for few-shot examples.
  *
  * Retrieves active and expired stories sorted by last update (most recently
  * edited first), which are most likely to have been reviewed by editors.
@@ -754,7 +754,7 @@ function babbel_fetch_recent_stories( int $limit = 20 ): array|\WP_Error {
 }
 
 /**
- * Clean up session data and debug information.
+ * Removes cached Babbel sessions.
  *
  * @since 0.1.0
  *

--- a/includes/few-shot-cache.php
+++ b/includes/few-shot-cache.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Few-shot example cache for AI prompt improvement
+ * Few-shot example caching for AI prompt improvement.
  *
  * Syncs editor-corrected stories from the Babbel API with their original WordPress
  * source content to build few-shot examples for AI speech text generation.
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Register the Action Scheduler hook for nightly few-shot sync.
+ * Registers the nightly synchronization hook.
  *
  * @since 0.3.0
  */
@@ -27,9 +27,7 @@ function few_shot_register_hook(): void {
 }
 
 /**
- * Schedule the nightly few-shot example sync.
- *
- * Uses Action Scheduler for reliable recurring execution.
+ * Schedules the nightly example synchronization.
  *
  * @since 0.3.0
  */
@@ -46,7 +44,7 @@ function few_shot_schedule_sync(): void {
 }
 
 /**
- * Unschedule the few-shot sync and clean up cached data.
+ * Cancels synchronization and clears cached examples.
  *
  * @since 0.3.0
  */
@@ -57,7 +55,7 @@ function few_shot_unschedule_sync(): void {
 }
 
 /**
- * Sync few-shot examples from Babbel API.
+ * Refreshes examples from the Babbel API.
  *
  * Fetches recent editor-reviewed stories, matches them with their original
  * WordPress posts, calculates edit-intensity scores, and caches the best
@@ -139,7 +137,7 @@ function sync_few_shot_examples(): void {
 }
 
 /**
- * Build few-shot candidates by matching Babbel stories with WordPress posts.
+ * Matches Babbel stories with WordPress posts.
  *
  * @since 0.3.0
  * @param array<int, array<string, mixed>> $stories Stories from the Babbel API.
@@ -203,7 +201,7 @@ function build_few_shot_candidates( array $stories ): array {
 }
 
 /**
- * Calculate edit-intensity score between AI-generated and editor-corrected text.
+ * Measures AI-to-editor text changes.
  *
  * Uses similar_text() to measure the percentage of difference.
  * A score of 0% means identical, 100% means completely rewritten.
@@ -226,7 +224,7 @@ function calculate_edit_score( string $ai_text, string $editor_text ): float {
 }
 
 /**
- * Select diverse examples ensuring a mix of short and long articles.
+ * Selects a mix of short and long articles.
  *
  * Splits candidates into short and long halves by word count, then picks
  * the highest-scoring examples from each half alternately.

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Global post hooks for story synchronization
+ * Global post hooks for story synchronization.
  *
  * These hooks run in all contexts (admin, REST API, CLI, cron) to ensure
  * stories are synced regardless of how posts are modified.
@@ -18,10 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Register global post and metadata hooks.
- *
- * These hooks must be registered in all contexts (admin, REST API, CLI, cron)
- * to ensure stories are synced regardless of how posts are modified.
+ * Registers post and metadata hooks.
  *
  * @since 0.2.0
  */
@@ -35,7 +32,7 @@ function register_post_hooks(): void {
 }
 
 /**
- * Synchronizes story state after the checkbox metadata changes.
+ * Reconciles state after a checkbox change.
  *
  * WordPress only fires the added/updated/deleted metadata actions after the
  * requested change has succeeded, so reconciliation can read the current
@@ -56,7 +53,7 @@ function handle_checkbox_meta_changed( $meta_id, $post_id, $meta_key ): void {
 }
 
 /**
- * Triggers story reconciliation after a post save.
+ * Reconciles story state after a post save.
  *
  * The previous post state lets sync_story_state() distinguish status
  * transitions from ordinary edits.
@@ -73,7 +70,7 @@ function handle_post_saved( int $post_id, \WP_Post $post, bool $update, ?\WP_Pos
 }
 
 /**
- * Reconciles the current WordPress post and Babbel story states.
+ * Reconciles the WordPress post and Babbel story states.
  *
  * This is the single source of truth for deciding whether a story should be
  * created, restored, updated, deleted, or left unchanged. Hook callbacks only
@@ -180,7 +177,7 @@ function sync_story_state( int $post_id, ?\WP_Post $post_before = null ): void {
 }
 
 /**
- * Restores a soft-deleted story and syncs the current post title.
+ * Restores a story and synchronizes its title.
  *
  * Uses PATCH to restore (deleted_at) then PUT to update the title,
  * matching the Babbel API contract where PATCH only accepts status/deleted_at.
@@ -241,7 +238,7 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
 }
 
 /**
- * Pushes a story update to Babbel and handles the result.
+ * Sends an update and records the result.
  *
  * On failure, logs the error while preserving the lifecycle state: the story
  * still exists in Babbel even though this synchronization attempt failed.
@@ -289,7 +286,7 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
 }
 
 /**
- * Deletes a story from Babbel and updates the local story state.
+ * Deletes a story and updates its local state.
  *
  * @since 0.4.0
  *
@@ -333,7 +330,7 @@ function push_story_delete( int $post_id, string $story_id, string $success_mess
 }
 
 /**
- * Detects date/title changes between post versions and builds update data.
+ * Returns data changed between post versions.
  *
  * Only the calendar day (Y-m-d) of the post date is compared: story dates are
  * day-granular, so a time-only edit can never change the Babbel payload.
@@ -364,7 +361,7 @@ function build_story_update_from_changes( \WP_Post $post, \WP_Post $post_before 
 }
 
 /**
- * Builds a full story update payload with dates derived from a base date.
+ * Builds a payload from a title and base date.
  *
  * @since 0.4.0
  *
@@ -386,9 +383,7 @@ function build_full_story_update( string $title, string $base_date ): array {
 }
 
 /**
- * Schedules story processing via Action Scheduler.
- *
- * Helper function to deduplicate scheduling logic.
+ * Queues deduplicated story processing.
  *
  * @since 0.2.0
  *

--- a/includes/story-status.php
+++ b/includes/story-status.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Story status enum definition
+ * Story processing status definitions.
  *
  * Defines the possible processing states for stories sent to the Babbel API.
  *
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Represents the processing status for a story.
+ * Represents the processing status of a story.
  *
  * @since 0.1.0
  */

--- a/includes/weekdays.php
+++ b/includes/weekdays.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Weekday bitmask values per Babbel API specification.
+ * Defines the Babbel weekday bitmask values.
  * Each day is a power of 2, starting with Sunday.
  */
 const WEEKDAY_SUNDAY    = 1;
@@ -27,7 +27,7 @@ const WEEKDAY_SATURDAY  = 64;
 const WEEKDAY_ALL       = 127;
 
 /**
- * Mapping of day names to bitmask values.
+ * Maps day names to bitmask values.
  * Order matches the bit positions (Sunday = bit 0).
  */
 const WEEKDAY_MAP = array(
@@ -41,7 +41,7 @@ const WEEKDAY_MAP = array(
 );
 
 /**
- * Convert plugin settings to weekdays bitmask.
+ * Converts plugin settings to a weekday bitmask.
  *
  * @since 0.1.0
  * @param array<string, mixed> $options Plugin settings array.

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPStan Bootstrap File
+ * PHPStan bootstrap definitions for static analysis.
  *
  * Defines constants and function stubs for static analysis only.
  * This file is NOT loaded at runtime and is excluded from release builds.
@@ -22,7 +22,7 @@ define( 'KNABBEL_PLUGIN_URL', 'https://example.com/wp-content/plugins/zw-knabbel
 // Action Scheduler function stubs for static analysis.
 if ( ! function_exists( 'as_schedule_single_action' ) ) {
 	/**
-	 * Schedule a single action to run at a specific time.
+	 * Stubs a single scheduled action.
 	 *
 	 * @param int    $timestamp When to run the action.
 	 * @param string $hook      The hook to trigger.
@@ -37,7 +37,7 @@ if ( ! function_exists( 'as_schedule_single_action' ) ) {
 
 if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
 	/**
-	 * Schedule a recurring action.
+	 * Stubs a recurring scheduled action.
 	 *
 	 * @param int    $timestamp         When to first run the action.
 	 * @param int    $interval_in_seconds How long to wait between runs.
@@ -53,7 +53,7 @@ if ( ! function_exists( 'as_schedule_recurring_action' ) ) {
 
 if ( ! function_exists( 'as_has_scheduled_action' ) ) {
 	/**
-	 * Check if there is a scheduled action for the given hook.
+	 * Stubs a scheduled-action lookup.
 	 *
 	 * @param string $hook  The hook to check.
 	 * @param array  $args  Arguments to check against.
@@ -67,7 +67,7 @@ if ( ! function_exists( 'as_has_scheduled_action' ) ) {
 
 if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
 	/**
-	 * Unschedule all actions matching the given hook and arguments.
+	 * Stubs bulk action cancellation.
 	 *
 	 * @param string $hook  The hook to unschedule.
 	 * @param array  $args  Arguments to match.
@@ -80,7 +80,7 @@ if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
 
 if ( ! function_exists( 'as_next_scheduled_action' ) ) {
 	/**
-	 * Get the next scheduled action for the given hook.
+	 * Stubs the next-action lookup.
 	 *
 	 * @param string $hook  The hook to check.
 	 * @param array  $args  Arguments to check against.

--- a/tests/e2e/mu-plugins/knabbel-e2e-control.php
+++ b/tests/e2e/mu-plugins/knabbel-e2e-control.php
@@ -25,7 +25,7 @@ add_filter(
 );
 
 /**
- * Run due Action Scheduler actions for a hook and fail loudly on errors.
+ * Runs due actions and fails on errors.
  *
  * Shared by the AJAX control endpoint below and tests/e2e/suite.php.
  *

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * End-to-end regression suite for the WordPress to Babbel synchronization flow.
+ * End-to-end tests for the WordPress-to-Babbel synchronization flow.
  *
  * @package KnabbelWP
  */
@@ -18,7 +18,7 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 }
 
 /**
- * Runs stateful integration scenarios against isolated WordPress and Babbel databases.
+ * Runs stateful scenarios against isolated databases.
  */
 final class Knabbel_E2E_Suite {
 	private const BABBEL_BASE_URL         = 'http://babbel:8080/api/v1';
@@ -65,7 +65,7 @@ final class Knabbel_E2E_Suite {
 	private string $published_story_id = '';
 
 	/**
-	 * Execute all scenarios in dependency order.
+	 * Executes all scenarios in dependency order.
 	 */
 	public function run(): void {
 		$this->run_case( 'E2E-001', 'recurring queue and Babbel authentication', $this->test_queue_and_authentication( ... ) );
@@ -91,7 +91,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Run one named case with useful failure context.
+	 * Runs one named case with useful failure context.
 	 *
 	 * @param string   $id       Stable scenario ID.
 	 * @param string   $title    Scenario title.
@@ -110,7 +110,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Configure deterministic credentials and story defaults.
+	 * Sets deterministic credentials and story defaults.
 	 *
 	 * @param string $password Babbel password.
 	 */
@@ -143,7 +143,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify a single recurring action, login and 401 retry.
+	 * Verifies queue uniqueness and authentication.
 	 */
 	private function test_queue_and_authentication(): void {
 		KnabbelWP\few_shot_schedule_sync();
@@ -177,7 +177,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify publish scheduling, queue execution, payload fidelity and send-once safety.
+	 * Verifies the complete publish flow.
 	 */
 	private function test_published_story_creation(): void {
 		$title          = 'E2E gepubliceerd – één';
@@ -242,7 +242,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify selective updates and recovery from a real Babbel authentication failure.
+	 * Verifies updates and authentication recovery.
 	 */
 	private function test_update_and_error_recovery(): void {
 		$original_story = $this->get_babbel_story( $this->published_story_id );
@@ -288,7 +288,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify checkbox-driven delete and restore against the real API.
+	 * Verifies checkbox-driven deletion and restoration.
 	 */
 	private function test_checkbox_delete_and_restore(): void {
 		update_post_meta( $this->published_post_id, self::SEND_TO_BABBEL_META_KEY, 0 );
@@ -305,7 +305,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify scheduled date calculation, rescheduling and future-to-publish recalculation.
+	 * Verifies scheduled-story date changes.
 	 */
 	private function test_scheduled_story_lifecycle(): void {
 		$post_id = $this->create_enabled_draft( 'E2E gepland', 'Een gepland artikel doorloopt dezelfde betrouwbare asynchrone integratieketen.' );
@@ -350,7 +350,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify pending work is canceled when a future post returns to draft.
+	 * Verifies cancellation after reverting to draft.
 	 */
 	private function test_pending_schedule_cancellation(): void {
 		$title   = 'E2E planning geannuleerd';
@@ -365,7 +365,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify post trash hooks soft-delete and untrash restores the same record.
+	 * Verifies trash and untrash synchronization.
 	 */
 	private function test_trash_and_restore(): void {
 		list( $post_id, $story_id ) = $this->create_sent_story( 'E2E prullenbak', 'Een gepubliceerd artikel wordt verwijderd en daarna veilig teruggezet.' );
@@ -383,7 +383,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify retry count and no remote side effect when the AI provider is unavailable.
+	 * Verifies retry behavior without remote side effects.
 	 */
 	private function test_ai_failure(): void {
 		$title = 'E2E AI-providerfout';
@@ -414,7 +414,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify a real Babbel login failure reaches per-story and operator diagnostics.
+	 * Verifies diagnostics after a login failure.
 	 */
 	private function test_babbel_create_failure(): void {
 		$title = 'E2E Babbel fout';
@@ -437,7 +437,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify the recurring integration learns edited remote text and clears cache when disabled.
+	 * Verifies learning and disabled-cache cleanup.
 	 */
 	private function test_few_shot_sync(): void {
 		$edited_text = 'Dit is de aantoonbaar door een redacteur aangepaste radiospreektekst.';
@@ -471,7 +471,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify both metadata hook variants enable already-public stories.
+	 * Verifies metadata hooks for existing posts.
 	 */
 	private function test_enable_existing_posts(): void {
 		$published_title = 'E2E bestaand gepubliceerd';
@@ -517,7 +517,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify pending work is canceled for both cancellable lifecycle states.
+	 * Verifies cancellation in eligible states.
 	 */
 	private function test_pending_work_cancellation(): void {
 		foreach ( array( 'checkbox', 'trash' ) as $cancel_via ) {
@@ -550,7 +550,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify all non-publish transitions away from future remove sent stories.
+	 * Verifies deletion after leaving future status.
 	 */
 	private function test_sent_story_unscheduling(): void {
 		foreach ( array( 'draft', 'pending', 'private', 'trash' ) as $new_status ) {
@@ -578,7 +578,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify metadata deletion and rapid changes use the same lifecycle rules.
+	 * Verifies rapid metadata changes.
 	 */
 	private function test_meta_deletion_and_rapid_toggles(): void {
 		$delete_title = 'E2E checkboxmeta verwijderd';
@@ -619,7 +619,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify scheduled and processing state guards prevent duplicate work.
+	 * Verifies duplicate-work prevention.
 	 */
 	private function test_in_flight_state_guards(): void {
 		$scheduled_id = $this->create_draft(
@@ -647,7 +647,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify restoring a post does not restore a deliberately disabled story.
+	 * Verifies disabled-story restoration behavior.
 	 */
 	private function test_untrash_with_checkbox_disabled(): void {
 		list( $post_id, $story_id ) = $this->create_sent_story(
@@ -666,7 +666,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify failed delete and restore transitions retain enough state to retry.
+	 * Verifies retryable failure state.
 	 */
 	private function test_delete_and_restore_failures(): void {
 		list( $post_id, $story_id ) = $this->create_sent_story(
@@ -704,7 +704,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Verify plugin lifecycle cleanup after all functional scenarios.
+	 * Verifies plugin lifecycle cleanup.
 	 */
 	private function test_deactivation_cleanup(): void {
 		$this->configure_plugin();
@@ -743,7 +743,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Create a draft post with radio news enabled and fail on WordPress errors.
+	 * Creates an enabled draft or fails on WordPress errors.
 	 *
 	 * @param string $title   Post title.
 	 * @param string $content Post content.
@@ -758,7 +758,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Create a draft post without checkbox metadata and fail on WordPress errors.
+	 * Creates a plain draft or fails on WordPress errors.
 	 *
 	 * @param string $title   Post title.
 	 * @param string $content Post content.
@@ -784,7 +784,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Update a post and fail on WordPress errors.
+	 * Updates a post or fails on WordPress errors.
 	 *
 	 * @param int                  $post_id Post ID.
 	 * @param array<string, mixed> $updates Post fields.
@@ -798,7 +798,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Publish a post and run its queued story processing.
+	 * Publishes and processes a post.
 	 *
 	 * @param int $post_id Post ID.
 	 */
@@ -808,7 +808,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Create an enabled draft, publish it and process it into a sent story.
+	 * Creates and processes a story to sent status.
 	 *
 	 * @param string $title   Post title.
 	 * @param string $content Post content.
@@ -823,7 +823,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Move a post to a future publication date.
+	 * Moves a post to a future publication date.
 	 *
 	 * @param int    $post_id Post ID.
 	 * @param string $date    Local MySQL datetime.
@@ -841,7 +841,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Run due actions through Action Scheduler's queue runner.
+	 * Runs due actions through the queue runner.
 	 *
 	 * Delegates to the shared helper in the knabbel-e2e-control MU plugin.
 	 *
@@ -860,7 +860,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Count scheduled actions by hook, status and optional action arguments.
+	 * Counts actions by hook, status, and arguments.
 	 *
 	 * @param string                    $hook   Action hook.
 	 * @param string                    $status Action Scheduler status.
@@ -883,7 +883,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Count pending story actions for one post.
+	 * Counts pending story actions for a post.
 	 *
 	 * @param int $post_id Post ID.
 	 * @return int Action count.
@@ -893,7 +893,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Issue an authenticated request using an independent test client.
+	 * Sends a request through the independent test client.
 	 *
 	 * @param string                    $method HTTP method.
 	 * @param string                    $path   API path below /api/v1.
@@ -926,7 +926,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Authenticate the independent verification client.
+	 * Authenticates the independent verification client.
 	 *
 	 * @throws RuntimeException When the HTTP request fails.
 	 */
@@ -956,7 +956,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Issue a GET request and decode the JSON response body.
+	 * Sends a GET request and decodes its JSON body.
 	 *
 	 * @param string $path    API path.
 	 * @param string $message Failure message for a non-200 response.
@@ -972,7 +972,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Fetch and decode one Babbel story.
+	 * Fetches and decodes one Babbel story.
 	 *
 	 * @param string $story_id Story ID.
 	 * @return array<string, mixed> Story response.
@@ -984,7 +984,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Count visible Babbel stories with an exact title.
+	 * Counts stories with an exact title.
 	 *
 	 * @param string $title Story title.
 	 * @return int Matching count.
@@ -1011,7 +1011,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Assert a response status without decoding the body.
+	 * Asserts a response status.
 	 *
 	 * @param int    $expected Expected status.
 	 * @param string $method   HTTP method.
@@ -1027,7 +1027,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Return a stable future local timestamp.
+	 * Returns a stable future local timestamp.
 	 *
 	 * @param int $days Days from now.
 	 * @return string MySQL datetime.
@@ -1037,7 +1037,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Normalize an API date or datetime to Y-m-d.
+	 * Normalizes an API date or datetime to Y-m-d.
 	 *
 	 * @param mixed $value API value.
 	 * @return string Date portion.
@@ -1047,7 +1047,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Assert the persisted story lifecycle status of a post.
+	 * Asserts the persisted lifecycle status.
 	 *
 	 * @param int         $post_id  Post ID.
 	 * @param StoryStatus $expected Expected status.
@@ -1058,7 +1058,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Assert a failed sync operation preserved the lifecycle state needed for a retry.
+	 * Asserts retryable lifecycle state.
 	 *
 	 * @param int         $post_id   Post ID.
 	 * @param string      $story_id  Expected Babbel story ID.
@@ -1074,7 +1074,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Assert start and end dates were calculated within a captured processing window.
+	 * Asserts dates within a processing window.
 	 *
 	 * @param array<string, mixed>  $story   Babbel story.
 	 * @param array<string, string> $before  Expected dates captured before processing.
@@ -1104,7 +1104,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Assert strict equality.
+	 * Asserts strict equality.
 	 *
 	 * @param mixed  $expected Expected value.
 	 * @param mixed  $actual   Actual value.
@@ -1119,7 +1119,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Assert a truthy condition.
+	 * Asserts a truthy condition.
 	 *
 	 * @param bool   $condition Condition.
 	 * @param string $message   Failure message.
@@ -1133,7 +1133,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Assert a false condition.
+	 * Asserts a false condition.
 	 *
 	 * @param bool   $condition Condition.
 	 * @param string $message   Failure message.
@@ -1143,7 +1143,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Assert a non-empty value.
+	 * Asserts a non-empty value.
 	 *
 	 * @param mixed  $value   Value.
 	 * @param string $message Failure message.
@@ -1157,7 +1157,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Assert one string contains another.
+	 * Asserts that one string contains another.
 	 *
 	 * @param string $needle  Required substring.
 	 * @param string $haystack Searched string.
@@ -1168,7 +1168,7 @@ final class Knabbel_E2E_Suite {
 	}
 
 	/**
-	 * Render a compact diagnostic value.
+	 * Renders a compact diagnostic value.
 	 *
 	 * @param mixed $value Value.
 	 * @return string Description.

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -45,15 +45,13 @@ require_once KNABBEL_PLUGIN_DIR . 'includes/babbel-api.php';
 require_once KNABBEL_PLUGIN_DIR . 'includes/ai-handler.php';
 require_once KNABBEL_PLUGIN_DIR . 'includes/few-shot-cache.php';
 
-/**
- * Initialize plugin hooks and actions.
- */
+// Register plugin lifecycle hooks.
 add_action( 'init', __NAMESPACE__ . '\\init' );
 register_activation_hook( __FILE__, __NAMESPACE__ . '\\activate' );
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\\deactivate' );
 
 /**
- * Checks whether Debug Mode is enabled.
+ * Reports whether Debug Mode is enabled.
  *
  * @since 0.1.0
  * @return bool True when debug mode is enabled, false otherwise.
@@ -63,7 +61,7 @@ function debug_enabled(): bool {
 }
 
 /**
- * Sanitizes and bounds context for the operator-facing recent error store.
+ * Bounds context for recent-error storage.
  *
  * Debug logs retain the complete context, but persistent production data is
  * limited to known diagnostic fields and excludes response/request bodies.
@@ -83,7 +81,7 @@ function prepare_log_context_for_storage( array $context ): array {
 }
 
 /**
- * Sanitize textual diagnostic context.
+ * Sanitizes textual diagnostic context.
  *
  * @since 0.4.0
  * @param array<string, mixed> $context Raw log context.
@@ -114,7 +112,7 @@ function prepare_log_text_context( array $context ): array {
 }
 
 /**
- * Sanitize scalar diagnostic context.
+ * Sanitizes scalar diagnostic context.
  *
  * @since 0.4.0
  * @param array<string, mixed> $context Raw log context.
@@ -133,7 +131,7 @@ function prepare_log_scalar_context( array $context ): array {
 }
 
 /**
- * Sanitize list-valued diagnostic context.
+ * Sanitizes list-valued diagnostic context.
  *
  * @since 0.4.0
  * @param array<string, mixed> $context Raw log context.
@@ -155,7 +153,7 @@ function prepare_log_list_context( array $context ): array {
 }
 
 /**
- * Prepares an error entry for bounded, non-sensitive persistent storage.
+ * Sanitizes an error for bounded storage.
  *
  * This also normalizes legacy entries before they are written back, ensuring
  * previously stored response bodies do not remain in the rolling list.
@@ -185,7 +183,7 @@ function prepare_recent_error_for_storage( array $entry ): ?array {
 }
 
 /**
- * Normalize a stored error history.
+ * Normalizes a stored error history.
  *
  * @since 0.4.0
  * @param mixed $stored_errors Stored option value.
@@ -214,7 +212,7 @@ function prepare_error_history( mixed $stored_errors ): array {
 }
 
 /**
- * Append an error to the shared history using bounded optimistic retries.
+ * Adds an error using bounded optimistic retries.
  *
  * This is a diagnostic buffer rather than an audit log. A collision never
  * overwrites another request's entry, while the small retry limit keeps error
@@ -280,7 +278,7 @@ function append_recent_error( array $new_error ): void {
 }
 
 /**
- * Centralized WordPress native logging with structured data.
+ * Writes structured diagnostics to WordPress logging and recent errors.
  *
  * @since 0.1.0
  * @param string               $level     Log level: 'error', 'warning', 'info'.
@@ -324,7 +322,7 @@ function log( string $level, string $component, string $message, array $context 
 }
 
 /**
- * Updates consolidated per-post story state metadata with WordPress native optimization.
+ * Updates consolidated story state metadata.
  *
  * Stores all state in `_knabbel_story_state` with single database operation.
  * Triggers WordPress action hook for extensibility.
@@ -337,7 +335,6 @@ function log( string $level, string $component, string $message, array $context 
  * @phpstan-param StoryStateUpdate $updates
  */
 function update_story_state( int $post_id, array $updates = array() ): bool {
-	// Single read operation.
 	$meta_value    = get_post_meta( $post_id, '_zw_knabbel_story_state', true );
 	$current_state = is_array( $meta_value ) ? $meta_value : array();
 
@@ -360,7 +357,6 @@ function update_story_state( int $post_id, array $updates = array() ): bool {
 		unset( $new_state['last_sync_error'] );
 	}
 
-	// Single write operation for all data.
 	$success = update_post_meta( $post_id, '_zw_knabbel_story_state', $new_state );
 
 	if ( $success ) {
@@ -380,13 +376,11 @@ function update_story_state( int $post_id, array $updates = array() ): bool {
 }
 
 /**
- * Get story state data for a post.
+ * Returns story state data for a post.
  *
  * @since 0.1.0
  * @param int $post_id The post ID.
- *
- * phpcs:ignore Generic.Files.LineLength.TooLong -- Type annotation.
- * @return array{status?: string, story_id?: string, status_changed_at?: string, message?: string, post_id?: int, last_sync_error?: array{message: string, occurred_at: string, operation: string}} Story state data or empty array if none exists.
+ * @return array<string, mixed> Story state data, or an empty array.
  *
  * @phpstan-return StoryState
  */
@@ -396,7 +390,7 @@ function get_story_state( int $post_id ): array {
 }
 
 /**
- * Builds a bounded sync error for persistent story state.
+ * Builds a bounded error for persistent story state.
  *
  * @since 0.4.0
  * @param string $message   Error message to show to operators and editors.
@@ -417,7 +411,7 @@ function build_story_sync_error( string $message, string $operation ): array {
 }
 
 /**
- * Reads a valid sync error from story state.
+ * Returns a valid sync error from story state.
  *
  * @since 0.4.0
  * @param array<string, mixed> $state Story state data.
@@ -442,7 +436,7 @@ function get_story_sync_error( array $state ): ?array {
 }
 
 /**
- * Determines whether a sync error has a message that can be rendered.
+ * Reports whether an error can be rendered.
  *
  * @since 0.4.0
  * @param array<string, mixed>|null $sync_error Sync error data.
@@ -458,7 +452,7 @@ function is_story_sync_error_renderable( ?array $sync_error ): bool {
 }
 
 /**
- * Calculate story dates based on a base date and configured offsets.
+ * Derives story dates from a base date and configured offsets.
  *
  * For published posts, base_date should be 'now'.
  * For scheduled posts, base_date should be the scheduled publish time (post_date).
@@ -483,9 +477,7 @@ function calculate_story_dates( string $base_date = 'now' ): array {
 }
 
 /**
- * Initializes the plugin.
- *
- * Loads text domain and registers hooks.
+ * Loads translations and registers plugin hooks.
  *
  * @since 0.1.0
  */
@@ -512,9 +504,7 @@ function init(): void {
 }
 
 /**
- * Initializes admin‑specific functionality.
- *
- * Loads admin functions and registers AJAX actions.
+ * Loads admin functions and registers their hooks.
  *
  * @since 0.1.0
  */
@@ -531,9 +521,7 @@ function admin_init(): void {
 }
 
 /**
- * Returns the default values for the knabbel_settings option.
- *
- * Single source of truth for the knabbel_settings defaults.
+ * Returns defaults for the knabbel_settings option.
  *
  * @since 0.6.0
  * @return array<string, mixed> The default settings.
@@ -563,7 +551,7 @@ function default_settings(): array {
 }
 
 /**
- * Returns the knabbel_settings option merged over the defaults.
+ * Returns stored settings merged over the defaults.
  *
  * Guarantees every default key exists, so read sites need no per-key fallbacks.
  *
@@ -575,9 +563,7 @@ function get_plugin_settings(): array {
 }
 
 /**
- * Runs on plugin activation.
- *
- * Creates the settings option and cleans legacy metadata.
+ * Initializes settings and scheduled work on activation.
  *
  * @since 0.1.0
  */
@@ -594,9 +580,7 @@ function activate(): void {
 }
 
 /**
- * Runs on plugin deactivation.
- *
- * Cleans up sessions and scheduled Action Scheduler jobs.
+ * Removes sessions and scheduled work on deactivation.
  *
  * @since 0.1.0
  */
@@ -612,7 +596,7 @@ function deactivate(): void {
 }
 
 /**
- * Cleanup deprecated data on activation.
+ * Removes deprecated settings during activation.
  *
  * Safe to run multiple times. Can be removed once all installs are on 0.4.0+.
  *
@@ -633,7 +617,7 @@ function cleanup_legacy_data(): void {
 }
 
 /**
- * Handles AJAX request to test the Babbel API connection.
+ * Handles an authorized Babbel connection test.
  *
  * @since 0.1.0
  */
@@ -654,9 +638,7 @@ function ajax_test_api(): void {
 }
 
 /**
- * Processes a story asynchronously via Action Scheduler.
- *
- * Generates AI content and sends it to the Babbel API.
+ * Generates and sends a story through Action Scheduler.
  *
  * @since 0.1.0
  * @param int|array{post_id?: int} $post_id_or_args The WordPress post ID or Action Scheduler args array.
@@ -670,7 +652,6 @@ function process_story_async( int|array $post_id_or_args ): void {
 		return;
 	}
 
-	// Debug logging for cron execution.
 	log( 'info', 'CronProcessor', 'Starting async story processing', array( 'post_id' => $post_id ) );
 
 		// Send-once safety: if already sent, do nothing.


### PR DESCRIPTION
## Summary

- audit comments and PHPDoc across all 14 PHP files
- align summaries and tags with the repository WordPress-Docs and WordPress-Extra standards
- shorten repetitive documentation and remove comments that merely restated the next line
- keep every comment line within the configured 160-character limit

## Validation

- `vendor/bin/phpcs --report=full`
- `vendor/bin/phpcs phpstan-bootstrap.php --standard=WordPress-Docs --report=full`
- PHP syntax check for all 14 PHP files
- `npm run lint`
- `git diff --check`
- verified the diff changes comments only
- hosted PHP 8.3, PHP 8.4, translations, Biome, ShellCheck, and Babbel E2E checks all pass

Local `composer phpstan` reports 10 unresolved WordPress AI Client classes/functions in `includes/ai-handler.php`; the hosted PHP lint jobs pass with the CI dependency environment.