### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -6,7 +6,7 @@
  * This file is only loaded in admin context.
  *
  * @package KnabbelWP
- * @since   0.0.1
+ * @since   0.1.0
  */
 
 declare(strict_types=1);
@@ -72,7 +72,7 @@ function metabox_add_status(): void {
 /**
  * Displays the Radionieuws control in the Publish metabox.
  *
- * @since 0.1.0
+ * @since 0.6.0
  *
  * @param \WP_Post $post The current post object.
  */

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -5,7 +5,7 @@
  * Manages plugin settings page, field registration, sanitization, and validation.
  *
  * @package KnabbelWP
- * @since   0.0.1
+ * @since   0.1.0
  */
 
 declare(strict_types=1);
@@ -30,7 +30,7 @@ function settings_init(): void {
 /**
  * Clears recent errors for an administrator.
  *
- * @since 0.4.0
+ * @since 0.5.0
  */
 function handle_clear_recent_errors(): void {
 	if ( ! current_user_can( 'manage_options' ) ) {
@@ -248,7 +248,7 @@ function settings_page(): void {
  * Only top-level fields are rendered. Stored context remains intentionally
  * hidden so nested API data can never become an unfiltered admin output path.
  *
- * @since 0.4.0
+ * @since 0.5.0
  */
 function render_recent_errors(): void {
 	if ( ! current_user_can( 'manage_options' ) ) {
@@ -330,7 +330,7 @@ function render_recent_errors(): void {
 /**
  * Returns the safe shape of a stored error.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param mixed $entry Raw entry from the knabbel_recent_errors option.
  * @return array{timestamp: string, component: string, message: string}|null Normalized entry, or null when invalid.
  */
@@ -352,7 +352,7 @@ function normalize_recent_error_entry( mixed $entry ): ?array {
 /**
  * Displays the Babbel API settings card.
  *
- * @since 0.1.05
+ * @since 0.1.0
  * @param array<string, mixed> $settings Current settings.
  */
 function render_babbel_api_card( array $settings ): void {
@@ -437,7 +437,7 @@ function render_babbel_api_card( array $settings ): void {
 /**
  * Displays the AI settings card.
  *
- * @since 0.1.05
+ * @since 0.5.0
  * @param array<string, mixed> $settings Current settings.
  */
 function render_ai_card( array $settings ): void {
@@ -527,7 +527,7 @@ function render_ai_card( array $settings ): void {
 /**
  * Displays the story defaults card.
  *
- * @since 0.1.05
+ * @since 0.1.0
  * @param array<string, mixed> $settings Current settings.
  */
 function render_defaults_card( array $settings ): void {
@@ -621,7 +621,7 @@ function render_defaults_card( array $settings ): void {
 /**
  * Displays the Verzonden Artikelen card.
  *
- * @since 0.1.05
+ * @since 0.1.0
  */
 function render_articles_overview(): void {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Debug post selector, no state change.

--- a/includes/ai-handler.php
+++ b/includes/ai-handler.php
@@ -5,7 +5,7 @@
  * Handles provider-independent speech text generation through WordPress Core.
  *
  * @package KnabbelWP
- * @since   0.0.1
+ * @since   0.5.0
  */
 
 declare(strict_types=1);
@@ -86,7 +86,7 @@ function ai_parse_model_setting( mixed $value ): ?array {
 /**
  * Generates speech text through the WordPress AI Client.
  *
- * @since 0.1.0
+ * @since 0.5.0
  * @param string $content The source content.
  * @return string|null The generated content or null on failure.
  */

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -5,7 +5,7 @@
  * Handles authentication, session management, and API communication with the Babbel API.
  *
  * @package KnabbelWP
- * @since   0.0.1
+ * @since   0.1.0
  */
 
 declare(strict_types=1);
@@ -36,7 +36,7 @@ function babbel_get_credentials(): array {
 /**
  * Builds the session transient key.
  *
- * @since 0.1.0
+ * @since 0.5.0
  * @param array{base_url: string, username: string, password: string}|null $credentials Optional credential snapshot.
  * @return string Transient key.
  *

--- a/includes/post-hooks.php
+++ b/includes/post-hooks.php
@@ -243,7 +243,7 @@ function restore_and_sync_story( int $post_id, string $story_id, string $title )
  * On failure, logs the error while preserving the lifecycle state: the story
  * still exists in Babbel even though this synchronization attempt failed.
  *
- * @since 0.4.0
+ * @since 0.5.0
  *
  * @param int                  $post_id         Post ID.
  * @param string               $story_id        Babbel story ID.
@@ -288,7 +288,7 @@ function push_story_update( int $post_id, string $story_id, array $update_data, 
 /**
  * Deletes a story and updates its local state.
  *
- * @since 0.4.0
+ * @since 0.5.0
  *
  * @param int    $post_id         Post ID.
  * @param string $story_id        Babbel story ID.
@@ -335,7 +335,7 @@ function push_story_delete( int $post_id, string $story_id, string $success_mess
  * Only the calendar day (Y-m-d) of the post date is compared: story dates are
  * day-granular, so a time-only edit can never change the Babbel payload.
  *
- * @since 0.4.0
+ * @since 0.5.0
  *
  * @param \WP_Post $post        Current post object.
  * @param \WP_Post $post_before Post object before the update.
@@ -363,7 +363,7 @@ function build_story_update_from_changes( \WP_Post $post, \WP_Post $post_before 
 /**
  * Builds a payload from a title and base date.
  *
- * @since 0.4.0
+ * @since 0.5.0
  *
  * @param string $title     The post title.
  * @param string $base_date Base date for calculate_story_dates() (e.g. 'now' or a post date).

--- a/includes/story-status.php
+++ b/includes/story-status.php
@@ -5,7 +5,7 @@
  * Defines the possible processing states for stories sent to the Babbel API.
  *
  * @package KnabbelWP
- * @since   0.0.1
+ * @since   0.1.0
  */
 
 declare(strict_types=1);

--- a/languages/zw-knabbel-wp-nl_NL.po
+++ b/languages/zw-knabbel-wp-nl_NL.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: ZuidWest Knabbel 0.5.0\n"
+"Project-Id-Version: ZuidWest Knabbel 0.6.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
 "POT-Creation-Date: 2026-08-11T15:06:31+00:00\n"
 "PO-Revision-Date: 2026-08-11T14:51:44+00:00\n"

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: ZuidWest Knabbel 0.5.0\n"
+"Project-Id-Version: ZuidWest Knabbel 0.6.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -6,7 +6,7 @@
  * This file is NOT loaded at runtime and is excluded from release builds.
  *
  * @package KnabbelWP
- * @since   0.0.1
+ * @since   0.1.0
  *
  * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
  */

--- a/uninstall.php
+++ b/uninstall.php
@@ -6,7 +6,7 @@
  * Settings and story data are preserved for potential reinstallation.
  *
  * @package KnabbelWP
- * @since   0.0.8
+ * @since   0.1.0
  */
 
 // Exit if not called by WordPress uninstaller.

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -3,7 +3,7 @@
  * Plugin Name: ZuidWest Knabbel
  * Plugin URI: https://github.com/oszuidwest/zw-knabbel-wp
  * Description: WordPress plugin om berichten naar de Babbel API te sturen voor het radionieuws. Gebruikt de WordPress AI Client voor AI-gegenereerde content.
- * Version: 0.5.0
+ * Version: 0.6.0
  * Requires at least: 7.0
  * Requires PHP: 8.3
  * Requires Plugins: classic-editor
@@ -66,7 +66,7 @@ function debug_enabled(): bool {
  * Debug logs retain the complete context, but persistent production data is
  * limited to known diagnostic fields and excludes response/request bodies.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param array<string, mixed> $context Raw log context.
  * @return array<string, mixed> Safe context for persistent storage.
  *
@@ -83,7 +83,7 @@ function prepare_log_context_for_storage( array $context ): array {
 /**
  * Sanitizes textual diagnostic context.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param array<string, mixed> $context Raw log context.
  * @return array<string, string>
  */
@@ -114,7 +114,7 @@ function prepare_log_text_context( array $context ): array {
 /**
  * Sanitizes scalar diagnostic context.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param array<string, mixed> $context Raw log context.
  * @return array<string, int|bool>
  */
@@ -133,7 +133,7 @@ function prepare_log_scalar_context( array $context ): array {
 /**
  * Sanitizes list-valued diagnostic context.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param array<string, mixed> $context Raw log context.
  * @return array<string, list<string>>
  */
@@ -158,7 +158,7 @@ function prepare_log_list_context( array $context ): array {
  * This also normalizes legacy entries before they are written back, ensuring
  * previously stored response bodies do not remain in the rolling list.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param array<string, mixed> $entry Raw error entry.
  * @return array<string, mixed>|null Sanitized entry, or null when invalid.
  *
@@ -185,7 +185,7 @@ function prepare_recent_error_for_storage( array $entry ): ?array {
 /**
  * Normalizes a stored error history.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param mixed $stored_errors Stored option value.
  * @return list<array<string, mixed>>
  *
@@ -218,7 +218,7 @@ function prepare_error_history( mixed $stored_errors ): array {
  * overwrites another request's entry, while the small retry limit keeps error
  * bursts from adding unbounded latency to the request that emitted the log.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param array<string, mixed> $new_error Prepared error entry.
  *
  * @phpstan-param RecentError $new_error
@@ -392,7 +392,7 @@ function get_story_state( int $post_id ): array {
 /**
  * Builds a bounded error for persistent story state.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param string $message   Error message to show to operators and editors.
  * @param string $operation Sync operation: create, update, restore, or delete.
  * @return array{message: string, occurred_at: string, operation: string} Sync error data.
@@ -413,7 +413,7 @@ function build_story_sync_error( string $message, string $operation ): array {
 /**
  * Returns a valid sync error from story state.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param array<string, mixed> $state Story state data.
  * @return array{message: string, occurred_at: string, operation: string}|null Sync error, or null when absent or malformed.
  *
@@ -438,7 +438,7 @@ function get_story_sync_error( array $state ): ?array {
 /**
  * Reports whether an error can be rendered.
  *
- * @since 0.4.0
+ * @since 0.5.0
  * @param array<string, mixed>|null $sync_error Sync error data.
  * @return bool Whether the sync error can be rendered.
  *


### PR DESCRIPTION
## Summary

- bump the plugin and translation metadata to version 0.6.0
- correct @since annotations against the first release tag containing each introduction commit
- account for renamed and replaced functions during the historical audit

## Historical audit

- checked 75 runtime functions with no remaining mismatches
- checked the StoryStatus enum and knabbel_story_state_changed hook
- checked nine file-level annotations
- manually reviewed the relevant AI, post-sync, settings, and metabox replacement commits

## Verification

- vendor/bin/phpcs
- composer phpstan
- npm run lint
- msgfmt --check -o /dev/null languages/zw-knabbel-wp-nl_NL.po
- git diff --check

## Manual testing

Not applicable; this PR only changes release and documentation metadata.