### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -94,6 +94,7 @@ function settings_register_settings(): void {
  * Sanitizes settings before storage.
  *
  * @since 0.1.0
+ * @since 0.7.0 Removed support for the `few_shot_count` setting.
  * @param array<string, mixed> $input The raw input array from the form.
  * @return array<string, mixed> The sanitized settings array.
  */
@@ -434,6 +435,7 @@ function render_babbel_api_card( array $settings ): void {
  * Displays the AI settings card.
  *
  * @since 0.5.0
+ * @since 0.7.0 Removed the configurable few-shot count field.
  * @param array<string, mixed> $settings Current settings.
  */
 function render_ai_card( array $settings ): void {

--- a/includes/ai-handler.php
+++ b/includes/ai-handler.php
@@ -89,6 +89,7 @@ function ai_parse_model_setting( mixed $value ): ?array {
  * Generates speech text through the WordPress AI Client.
  *
  * @since 0.5.0
+ * @since 0.7.0 Added the `$current_post_id` parameter and curated example mix.
  * @param string $content         The source content.
  * @param int    $current_post_id Current post ID to exclude from examples, 0 for none.
  * @return string|null The generated content or null on failure.

--- a/includes/babbel-api.php
+++ b/includes/babbel-api.php
@@ -672,6 +672,7 @@ function babbel_restore_story( string $story_id ): array {
  * edited first), which are most likely to have been reviewed by editors.
  *
  * @since 0.3.0
+ * @since 0.7.0 Replaced the `$limit` parameter with `$created_after` and added response validation.
  * @param string $created_after Inclusive ISO 8601 creation cutoff.
  * @return array<int, array<string, mixed>>|\WP_Error Array of story objects or WP_Error on failure.
  */

--- a/includes/few-shot-cache.php
+++ b/includes/few-shot-cache.php
@@ -76,6 +76,7 @@ function few_shot_cutoff_timestamp(): int {
  * be excluded without reducing the configured example count.
  *
  * @since 0.3.0
+ * @since 0.7.0 Stores a recent candidate pool for per-request selection.
  */
 function sync_few_shot_examples(): void {
 	$stories = babbel_fetch_recent_stories( gmdate( DATE_ATOM, few_shot_cutoff_timestamp() ) );
@@ -115,6 +116,7 @@ function sync_few_shot_examples(): void {
  * Matches recent Babbel stories with their WordPress sources.
  *
  * @since 0.3.0
+ * @since 0.7.0 Added age, quality, duplicate, and provenance handling.
  * @param array<int, array<string, mixed>> $stories Stories from the Babbel API.
  * @return array<int, array<string, mixed>> Candidate examples.
  *

--- a/includes/few-shot-selection.php
+++ b/includes/few-shot-selection.php
@@ -71,6 +71,7 @@ function few_shot_count_sentences( string $text ): int {
  * Uses byte-level distance, sufficient for provenance and coarse ranking.
  *
  * @since 0.3.0
+ * @since 0.7.0 Normalizes inputs and uses Levenshtein distance.
  * @param string $ai_text     Original AI-generated text.
  * @param string $editor_text Text stored in Babbel.
  * @return float Percentage of difference (0.0 to 100.0).
@@ -130,6 +131,7 @@ function normalize_few_shot_candidate( array $candidate ): ?array {
  * Selects examples spanning output length, edit score, source length and sentences.
  *
  * @since 0.3.0
+ * @since 0.7.0 Diversifies across four metrics using the expanded candidate shape.
  * @param array<int, array<string, mixed>> $candidates Candidate examples.
  * @param int                              $max_count  Maximum examples to select.
  * @return array<int, array<string, mixed>> Selected examples.

--- a/languages/zw-knabbel-wp-nl_NL.po
+++ b/languages/zw-knabbel-wp-nl_NL.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: ZuidWest Knabbel 0.6.0\n"
+"Project-Id-Version: ZuidWest Knabbel 0.7.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
 "POT-Creation-Date: 2026-08-11T20:01:30+00:00\n"
 "PO-Revision-Date: 2026-08-11T14:51:44+00:00\n"

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: ZuidWest Knabbel 0.6.0\n"
+"Project-Id-Version: ZuidWest Knabbel 0.7.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -3,7 +3,7 @@
  * Plugin Name: ZuidWest Knabbel
  * Plugin URI: https://github.com/oszuidwest/zw-knabbel-wp
  * Description: WordPress plugin om berichten naar de Babbel API te sturen voor het radionieuws. Gebruikt de WordPress AI Client voor AI-gegenereerde content.
- * Version: 0.6.0
+ * Version: 0.7.0
  * Requires at least: 7.0
  * Requires PHP: 8.3
  * Requires Plugins: classic-editor
@@ -525,6 +525,7 @@ function admin_init(): void {
  * Returns defaults for the knabbel_settings option.
  *
  * @since 0.6.0
+ * @since 0.7.0 Removed the `few_shot_count` setting.
  * @return array<string, mixed> The default settings.
  */
 function default_settings(): array {
@@ -601,6 +602,7 @@ function deactivate(): void {
  * removed up to and including 0.7.0.
  *
  * @since 0.1.0
+ * @since 0.7.0 Removes the obsolete `few_shot_count` setting.
  */
 function cleanup_legacy_data(): void {
 	// Raw read on purpose: this rewrites the stored value, and reading through
@@ -641,6 +643,7 @@ function ajax_test_api(): void {
  * Generates and sends a story through Action Scheduler.
  *
  * @since 0.1.0
+ * @since 0.7.0 Excludes the current post from the AI few-shot examples.
  * @param int|array{post_id?: int} $post_id_or_args The WordPress post ID or Action Scheduler args array.
  */
 function process_story_async( int|array $post_id_or_args ): void {


### PR DESCRIPTION
## Summary

- bump the plugin and translation metadata to version 0.7.0
- audit `@since` annotations for every runtime change since 0.6.0
- add 0.7.0 changelog entries for significant parameter and behavior changes

## Since audit

- compared the runtime function set with tag 0.6.0: seven additions and no removals
- confirmed all seven new functions use `@since 0.7.0`
- preserved the original `0.3.0` introduction tags for moved functions
- documented eleven significantly changed functions with an additional `@since 0.7.0` entry

## Verification

- `composer test`
- `vendor/bin/phpcs`
- `composer phpstan`
- `npm run lint`
- `composer validate --strict`
- `composer audit`
- `npm audit --audit-level=high`
- `shellcheck tests/e2e/run.sh`
- `msgfmt --check -o /dev/null languages/zw-knabbel-wp-nl_NL.po`
- `git diff --check`

## Manual testing

Not applicable; this PR only changes release and documentation metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin documentation for the 0.7.0 release.
  * Documented removal of the configurable few-shot example count.
  * Clarified story processing and AI example selection behavior.
  * Documented updated story API parameters, response validation, and scoring improvements.

* **Localization**
  * Updated translation catalog version metadata to 0.7.0.

* **Chores**
  * Updated the plugin version from 0.6.0 to 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->