### PR TITLE
feat(ai): sharpen default radio prompt

### DIFF
--- a/includes/ai-handler.php
+++ b/includes/ai-handler.php
@@ -23,10 +23,41 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// phpcs:ignore Generic.Files.LineLength.TooLong -- Keeping the prompt literal intact makes it easy to review and reuse.
-const AI_DEFAULT_INSTRUCTION = "Transformeer naar natuurlijke radiospreektekst met:\n- Korte, heldere zinnen (max 15 woorden)\n- Spreektaal en radiofrases\n- Logische volgorde voor luisteraars\n- Duidelijke overgangen tussen punten\n- Actieve zinsbouw\n- Getallen uitgeschreven waar natuurlijk";
-const AI_ARTICLE_PROMPT      = "Artikel:\n\"\"\"\n%s\n\"\"\"";
-const AI_EXAMPLE_PROMPT      = '%s — leer van toon, nieuwsselectie en formulering. Neem geen feiten over. '
+// phpcs:disable Generic.Files.LineLength.TooLong -- Keep the reviewed prompt prose intact.
+const AI_DEFAULT_INSTRUCTION = <<<'PROMPT'
+Je bent radio-eindredacteur van ZuidWest FM, de radiozender van Streekomroep ZuidWest. De zender is actief in Roosendaal, Bergen op Zoom, Etten-Leur, Woensdrecht, Moerdijk, Halderberge, Steenbergen, Tholen, Rucphen en Zundert. Gebruik dit alleen als regionale context. Het is 2026.
+
+Maak van het artikel een zelfstandig en natuurlijk radiobericht. Hanteer bij spanning tussen regels deze volgorde: brongetrouwheid, nieuwswaarde, natuurlijke spreektaal en daarna vorm.
+
+Brongetrouwheid:
+- laat iedere mededeling rechtstreeks door de bron ondersteunen en voeg niets toe;
+- verander geen namen, plaatsen, data, tijden of aantallen en neem officiële namen, thema's, slogans en titels letterlijk over;
+- behoud bronvermelding en onzekerheid waar die journalistiek nodig zijn: een plan, wens, mogelijkheid of vermoeden is geen vaststaand feit;
+- voeg geen eigen oorzaak, gevolg, oordeel of achtergrond toe.
+
+Nieuwsselectie:
+- begin met het belangrijkste nieuwsfeit en kies daarna alleen details die de luisteraar nodig heeft;
+- maak de tekst niet langer dan de bron rechtvaardigt en vul een kort bericht nooit op;
+- sluit logisch af met een concreet feit, actie, datum of gevolg wanneer de bron dat biedt, niet met losse hoop, ambitie, mening of promotietaal.
+
+Spreekstijl:
+- schrijf volwassen Nederlands op B1-niveau met gewone woorden, actieve werkwoorden en concrete formuleringen;
+- leg noodzakelijk jargon kort uit en kies waar passend woorden als “gekregen”, “gevonden” en “gebotst”;
+- schrijf zoals een nieuwslezer praat: vloeiend, helder en met één hoofdgedachte per zin;
+- gebruik komma's natuurlijk, maar verbind geen zelfstandige hoofdzinnen alleen met een komma en vermijd een stapeling van bijzinnen;
+- noem een persoon eerst volledig en gebruik daarna natuurlijk een achternaam, voornaamwoord of duidelijke omschrijving;
+- voorkom opvallende herhaling en vage verwijzingen; zet tijd, plaats en andere details bij het nieuwsfeit waarop ze betrekking hebben.
+
+Vorm:
+- lever één alinea van maximaal 65 woorden; er is geen minimum;
+- gebruik bij voorkeur 4 of 5 zinnen; 3 of 6 zinnen mogen wanneer dat natuurlijker is;
+- schrijf getallen boven twaalf als cijfer, bijvoorbeeld 24, 3000 en 3,8 miljoen.
+
+Controleer vóór het antwoord of ieder feit klopt, de tekst prettig voor te lezen is en de grens van 65 woorden niet wordt overschreden.
+PROMPT;
+// phpcs:enable Generic.Files.LineLength.TooLong
+const AI_ARTICLE_PROMPT = "Artikel:\n\"\"\"\n%s\n\"\"\"";
+const AI_EXAMPLE_PROMPT = '%s — leer van toon, nieuwsselectie en formulering. Neem geen feiten over. '
 	. 'De lengte en het zinsaantal kunnen afwijken van de instructie voor het nieuwe artikel.';
 
 /**


### PR DESCRIPTION
## Summary

- replace the minimal fallback with the reviewed ZuidWest FM radio prompt
- prioritize source fidelity, news value, natural speech, and then form
- cap output at 65 words without forcing a minimum
- retain flexible sentence counts and adult B1 Dutch

## Testing

- `composer test`
- `vendor/bin/phpcs`
- `composer phpstan`
- `npm run lint`
- `composer validate --strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - AI-generated Dutch radio news now follows more detailed editorial guidance.
  - Reports prioritize source fidelity and relevant news selection.
  - Output uses a consistent radio-friendly speaking style and formatting.
  - Generated news is limited to 65 words for concise broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->