### PR TITLE
fix(ai): omit unsupported temperature parameter

### DIFF
--- a/includes/ai-handler.php
+++ b/includes/ai-handler.php
@@ -148,8 +148,7 @@ function ai_generate_content( string $content, int $current_post_id ): ?string {
 	for ( $attempt = 1; $attempt <= $max_attempts; ++$attempt ) {
 		$prompt = wp_ai_client_prompt( $messages )
 			->using_system_instruction( $instruction )
-			->using_max_tokens( 1000 )
-			->using_temperature( 0.7 );
+			->using_max_tokens( 1000 );
 		if ( null !== $model_preference ) {
 			$prompt = $prompt->using_model_preference( $model_preference );
 		}

--- a/tests/e2e/mu-plugins/knabbel-ai-client-stub.php
+++ b/tests/e2e/mu-plugins/knabbel-ai-client-stub.php
@@ -34,13 +34,20 @@ add_filter(
 
 			update_option( 'knabbel_e2e_ai_call_count', (int) get_option( 'knabbel_e2e_ai_call_count', 0 ) + 1, false );
 
-			if ( 'error' === get_option( 'knabbel_e2e_ai_mode', 'success' ) ) {
-				return new WP_Error( 'knabbel_e2e_ai_error', 'Deterministic AI provider failure' );
-			}
-
 			$request_body = json_decode( (string) ( $parsed_args['body'] ?? '' ), true );
 			if ( is_array( $request_body ) ) {
 				update_option( 'knabbel_e2e_ai_last_request', $request_body, false );
+
+				if ( array_key_exists( 'temperature', $request_body ) ) {
+					return new WP_Error(
+						'knabbel_e2e_ai_unsupported_parameter',
+						'Unsupported parameter: temperature is not supported with this model.'
+					);
+				}
+			}
+
+			if ( 'error' === get_option( 'knabbel_e2e_ai_mode', 'success' ) ) {
+				return new WP_Error( 'knabbel_e2e_ai_error', 'Deterministic AI provider failure' );
 			}
 
 			$body = array(

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -241,7 +241,7 @@ final class Knabbel_E2E_Suite {
 		$ai_request = get_option( 'knabbel_e2e_ai_last_request', array() );
 		$this->assert_same( true, is_array( $ai_request ), 'The native AI provider request must be observable.' );
 		$this->assert_same( 1000, $ai_request['max_output_tokens'] ?? null, 'The native AI request must retain the output token limit.' );
-		$this->assert_same( 0.7, $ai_request['temperature'] ?? null, 'The native AI request must retain the configured temperature.' );
+		$this->assert_same( false, array_key_exists( 'temperature', $ai_request ), 'The native AI request must omit optional temperature.' );
 		$this->assert_same( 'gpt-4.1', $ai_request['model'] ?? null, 'The native AI request must use the configured model preference.' );
 		$request_messages = $ai_request['input'] ?? array();
 		$this->assert_same( true, is_array( $request_messages ), 'The native AI request input must contain structured messages.' );


### PR DESCRIPTION
## Summary

- stop adding the optional temperature parameter to speech-text prompts
- keep the system instruction, maximum output token limit, and configured model preference unchanged
- make the Docker AI provider stub reject temperature so the full publish flow guards against regressions

## Investigation

The selected model can satisfy the text-generation capability check while still rejecting an optional request parameter at runtime. Because every retry reused the same temperature value, all three requests failed and processing returned before creating the Babbel story. Omitting the parameter lets each provider and model use its supported default.

AI Provider for OpenAI 1.0.3 cannot reliably prevent this failure. Upstream PR [WordPress/ai-provider-for-openai#40](https://github.com/WordPress/ai-provider-for-openai/pull/40) documents that the provider advertised temperature and other sampling options for every text-generation model, allowing incompatible models to pass requirement-based resolution and fail only at the OpenAI API. That upstream change remains open, and runtime-specific restrictions for custom or fine-tuned models may still be more precise than provider metadata.

The regression was reproduced before the production change: the Docker provider returned the production-style unsupported-parameter error, Playwright reached the queued worker, and no story ID was created. After the change, the same browser flow created the story successfully and the captured provider request contained no temperature field.

## Test plan

- vendor/bin/phpcs
- vendor/bin/phpcs tests/e2e/mu-plugins/knabbel-ai-client-stub.php tests/e2e/suite.php
- composer phpstan
- composer test
- npm run lint
- git diff --check
- BABBEL_PATH=../zwfm-babbel tests/e2e/run.sh (4 Playwright tests; 18 PHP E2E scenarios; 232 assertions)

Closes #63