### PR TITLE
refactor: simplify plugin internals

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -404,24 +404,6 @@
     gap: 8px;
 }
 
-.knabbel-action-retry {
-    display: inline-flex;
-    align-items: center;
-    padding: 6px 12px;
-    font-size: 13px;
-    font-weight: 500;
-    border-radius: 3px;
-    cursor: pointer;
-    background: #fff;
-    color: #d63638;
-    border: 1px solid #d63638;
-}
-
-.knabbel-action-retry:hover {
-    background: #d63638;
-    color: #fff;
-}
-
 .knabbel-refresh {
     background: none;
     border: 1px solid #c3c4c7;

--- a/includes/admin/metabox.php
+++ b/includes/admin/metabox.php
@@ -102,7 +102,7 @@ function submitbox_render( \WP_Post $post ): void {
 			<span class="knabbel-submitbox-toggle-disabled" aria-hidden="true"><?php esc_html_e( 'No', 'zw-knabbel-wp' ); ?></span>
 		</label>
 
-		<?php if ( is_story_sync_error_renderable( $sync_error ) ) : ?>
+		<?php if ( null !== $sync_error ) : ?>
 			<div class="knabbel-sync-warning" role="alert">
 				<strong><?php esc_html_e( 'Babbel sync warning', 'zw-knabbel-wp' ); ?></strong>
 				<div><?php echo esc_html( $sync_error['message'] ); ?></div>
@@ -133,25 +133,14 @@ function metabox_render_status( \WP_Post $post ): void {
 				<strong><?php esc_html_e( 'Status', 'zw-knabbel-wp' ); ?>:</strong>
 				<?php
 				$status_slug = $status ? sanitize_key( $status ) : 'none';
-				$label_map   = array(
-					'scheduled'  => __( 'Scheduled', 'zw-knabbel-wp' ),
-					'processing' => __( 'Processing', 'zw-knabbel-wp' ),
-					'sent'       => __( 'Sent', 'zw-knabbel-wp' ),
-					'error'      => __( 'Error', 'zw-knabbel-wp' ),
-					'deleted'    => __( 'Deleted', 'zw-knabbel-wp' ),
-				);
-				$label       = $status && isset( $label_map[ $status ] ) ? $label_map[ $status ] : ( $status ? $status : __( '—', 'zw-knabbel-wp' ) );
+				$label       = $status ? ( StoryStatus::tryFrom( $status )?->label() ?? $status ) : __( '—', 'zw-knabbel-wp' );
 				echo '<span class="knabbel-status-badge ' . esc_attr( $status_slug ) . '">' . esc_html( $label ) . '</span>';
 				?>
 			</li>
 			<?php if ( ! empty( $updated ) ) : ?>
 			<li class="knabbel-status-muted">
 				<?php esc_html_e( 'Last status change:', 'zw-knabbel-wp' ); ?>
-				<?php
-				// status_changed_at is stored as local time string via current_time('mysql').
-				$updated_ts = strtotime( $updated . ' ' . wp_timezone_string() );
-				echo esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $updated_ts ) );
-				?>
+				<?php echo esc_html( format_stored_datetime( $updated ) ); ?>
 			</li>
 			<?php endif; ?>
 			<?php if ( ! empty( $story_id ) ) : ?>
@@ -165,35 +154,28 @@ function metabox_render_status( \WP_Post $post ): void {
 				<?php esc_html_e( 'Scheduled:', 'zw-knabbel-wp' ); ?>
 				<?php
 				// Action Scheduler returns UTC timestamp.
-				echo esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $scheduled ) );
+				echo esc_html( format_stored_datetime( (int) $scheduled ) );
 				?>
 			</li>
 			<?php endif; ?>
-			<?php if ( is_story_sync_error_renderable( $sync_error ) ) : ?>
+			<?php if ( null !== $sync_error ) : ?>
 			<li>
 				<strong><?php esc_html_e( 'Last sync error', 'zw-knabbel-wp' ); ?>:</strong>
 				<div class="knabbel-sync-warning">
 					<?php echo esc_html( $sync_error['message'] ); ?>
-					<?php if ( ! empty( $sync_error['operation'] ) || ! empty( $sync_error['occurred_at'] ) ) : ?>
-						<div class="knabbel-status-muted">
-							<?php if ( ! empty( $sync_error['operation'] ) ) : ?>
-								<?php esc_html_e( 'Operation', 'zw-knabbel-wp' ); ?>:
-								<code><?php echo esc_html( $sync_error['operation'] ); ?></code>
-							<?php endif; ?>
-							<?php if ( ! empty( $sync_error['occurred_at'] ) ) : ?>
-								<?php
-								$sync_error_ts = strtotime( $sync_error['occurred_at'] . ' ' . wp_timezone_string() );
-								if ( $sync_error_ts ) {
-									echo ' · ' . esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $sync_error_ts ) );
-								}
-								?>
-							<?php endif; ?>
-						</div>
-					<?php endif; ?>
+					<div class="knabbel-status-muted">
+						<?php if ( ! empty( $sync_error['operation'] ) ) : ?>
+							<?php esc_html_e( 'Operation', 'zw-knabbel-wp' ); ?>:
+							<code><?php echo esc_html( $sync_error['operation'] ); ?></code>
+						<?php endif; ?>
+						<?php if ( ! empty( $sync_error['occurred_at'] ) ) : ?>
+							<?php echo ' · ' . esc_html( format_stored_datetime( $sync_error['occurred_at'] ) ); ?>
+						<?php endif; ?>
+					</div>
 				</div>
 			</li>
 			<?php endif; ?>
-			<?php if ( ! empty( $message ) && ! is_story_sync_error_renderable( $sync_error ) ) : ?>
+			<?php if ( ! empty( $message ) && null === $sync_error ) : ?>
 			<li>
 				<strong><?php esc_html_e( 'Message', 'zw-knabbel-wp' ); ?>:</strong>
 				<div class="knabbel-pre"><?php echo esc_html( $message ); ?></div>

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -39,14 +39,12 @@ function handle_clear_recent_errors(): void {
 
 	check_admin_referer( 'knabbel_clear_recent_errors' );
 
-	$missing_option = new \stdClass();
-	$stored_errors  = get_option( 'knabbel_recent_errors', $missing_option );
-	$errors_cleared = $missing_option === $stored_errors || delete_option( 'knabbel_recent_errors' );
+	delete_option( 'knabbel_recent_errors' );
 
 	$redirect_url = add_query_arg(
 		array(
 			'page'                   => 'zw-knabbel-wp-settings',
-			'knabbel_errors_cleared' => $errors_cleared ? '1' : '0',
+			'knabbel_errors_cleared' => '1',
 		),
 		admin_url( 'options-general.php' )
 	);
@@ -203,10 +201,6 @@ function settings_page(): void {
 			<div class="notice notice-success is-dismissible">
 				<p><?php esc_html_e( 'Recent errors cleared.', 'zw-knabbel-wp' ); ?></p>
 			</div>
-		<?php elseif ( '0' === $clear_status ) : ?>
-			<div class="notice notice-error is-dismissible">
-				<p><?php esc_html_e( 'Recent errors could not be cleared. Please try again.', 'zw-knabbel-wp' ); ?></p>
-			</div>
 		<?php endif; ?>
 		<!-- Page Header -->
 		<div class="knabbel-page-header">
@@ -257,13 +251,7 @@ function render_recent_errors(): void {
 		return;
 	}
 
-	$recent_errors = array();
-	foreach ( array_reverse( $stored_errors ) as $entry ) {
-		$normalized_entry = normalize_recent_error_entry( $entry );
-		if ( null !== $normalized_entry ) {
-			$recent_errors[] = $normalized_entry;
-		}
-	}
+	$recent_errors = array_reverse( prepare_error_history( $stored_errors ) );
 
 	?>
 	<div id="knabbel-recent-errors" class="knabbel-settings-card" style="margin-top: 24px;">
@@ -289,20 +277,8 @@ function render_recent_errors(): void {
 						</tr>
 					<?php else : ?>
 						<?php foreach ( $recent_errors as $entry ) : ?>
-							<?php
-							$timestamp    = $entry['timestamp'];
-							$timestamp_ts = $timestamp ? strtotime( $timestamp . ' ' . wp_timezone_string() ) : false;
-							?>
 							<tr>
-								<td>
-									<?php
-									echo esc_html(
-										$timestamp_ts
-											? wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp_ts )
-											: $timestamp
-									);
-									?>
-								</td>
+								<td><?php echo esc_html( format_stored_datetime( $entry['timestamp'] ) ); ?></td>
 								<td class="mono"><?php echo esc_html( $entry['component'] ); ?></td>
 								<td class="error-message"><?php echo esc_html( $entry['message'] ); ?></td>
 							</tr>
@@ -322,28 +298,6 @@ function render_recent_errors(): void {
 		</div>
 	</div>
 	<?php
-}
-
-/**
- * Returns the safe shape of a stored error.
- *
- * @since 0.5.0
- * @param mixed $entry Raw entry from the knabbel_recent_errors option.
- * @return array{timestamp: string, component: string, message: string}|null Normalized entry, or null when invalid.
- */
-function normalize_recent_error_entry( mixed $entry ): ?array {
-	if ( ! is_array( $entry ) || ! isset( $entry['component'], $entry['message'] ) ) {
-		return null;
-	}
-	if ( ! is_scalar( $entry['component'] ) || ! is_scalar( $entry['message'] ) ) {
-		return null;
-	}
-
-	return array(
-		'timestamp' => isset( $entry['timestamp'] ) && is_scalar( $entry['timestamp'] ) ? (string) $entry['timestamp'] : '',
-		'component' => (string) $entry['component'],
-		'message'   => (string) $entry['message'],
-	);
 }
 
 /**
@@ -653,13 +607,11 @@ function render_articles_overview(): void {
 	// Select current item.
 	$selected       = null;
 	$selected_state = null;
-	$selected_ts    = 0;
 	if ( $selected_id && ! empty( $candidates ) ) {
 		foreach ( $candidates as $item ) {
 			if ( $item['post']->ID === $selected_id ) {
 				$selected       = $item['post'];
 				$selected_state = $item['state'];
-				$selected_ts    = $item['ts'];
 				break;
 			}
 		}
@@ -667,7 +619,6 @@ function render_articles_overview(): void {
 	if ( ! $selected && $latest_post ) {
 		$selected       = $latest_post;
 		$selected_state = $latest_state;
-		$selected_ts    = $latest_ts;
 	}
 
 	if ( ! $selected || ! $selected_state ) {
@@ -675,14 +626,8 @@ function render_articles_overview(): void {
 	}
 
 	$status     = $selected_state['status'] ?? '';
-	$label_map  = array(
-		'scheduled'  => __( 'Scheduled', 'zw-knabbel-wp' ),
-		'processing' => __( 'Processing', 'zw-knabbel-wp' ),
-		'sent'       => __( 'Sent', 'zw-knabbel-wp' ),
-		'error'      => __( 'Error', 'zw-knabbel-wp' ),
-	);
 	$slug       = $status ? sanitize_key( $status ) : 'none';
-	$label      = $status ? ( $label_map[ $status ] ?? $status ) : '—';
+	$label      = $status ? ( StoryStatus::tryFrom( $status )?->label() ?? $status ) : '—';
 	$is_error   = 'error' === $status;
 	$is_sent    = 'sent' === $status;
 	$sync_error = get_story_sync_error( $selected_state );
@@ -743,7 +688,7 @@ function render_articles_overview(): void {
 				<tr>
 					<td class="label-cell"><?php esc_html_e( 'Last status change', 'zw-knabbel-wp' ); ?></td>
 					<td>
-						<?php echo esc_html( wp_date( get_option( 'date_format' ) . ', ' . get_option( 'time_format' ), $selected_ts ) ); ?>
+						<?php echo esc_html( format_stored_datetime( $selected_state['status_changed_at'] ) ); ?>
 					</td>
 				</tr>
 				<?php if ( $is_sent && ! empty( $selected_state['story_id'] ) ) : ?>
@@ -752,7 +697,7 @@ function render_articles_overview(): void {
 					<td class="mono"><?php echo esc_html( $selected_state['story_id'] ); ?></td>
 				</tr>
 				<?php endif; ?>
-				<?php if ( $is_error && ! empty( $selected_state['message'] ) && ! is_story_sync_error_renderable( $sync_error ) ) : ?>
+				<?php if ( $is_error && ! empty( $selected_state['message'] ) && null === $sync_error ) : ?>
 				<tr>
 					<td class="label-cell"><?php esc_html_e( 'Message', 'zw-knabbel-wp' ); ?></td>
 					<td class="error-message"><?php echo esc_html( $selected_state['message'] ); ?></td>
@@ -768,7 +713,7 @@ function render_articles_overview(): void {
 					<td class="muted">—</td>
 				</tr>
 				<?php endif; ?>
-				<?php if ( is_story_sync_error_renderable( $sync_error ) ) : ?>
+				<?php if ( null !== $sync_error ) : ?>
 				<tr>
 					<td class="label-cell"><?php esc_html_e( 'Last sync error', 'zw-knabbel-wp' ); ?></td>
 					<td class="error-message">
@@ -779,30 +724,16 @@ function render_articles_overview(): void {
 								<code><?php echo esc_html( $sync_error['operation'] ); ?></code>
 							</div>
 						<?php endif; ?>
-						<?php
-						$sync_error_ts = strtotime( $sync_error['occurred_at'] . ' ' . wp_timezone_string() );
-						if ( $sync_error_ts ) :
-							?>
-							<div class="muted">
-								<?php esc_html_e( 'Occurred', 'zw-knabbel-wp' ); ?>:
-								<?php echo esc_html( wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $sync_error_ts ) ); ?>
-							</div>
-						<?php endif; ?>
+						<div class="muted">
+							<?php esc_html_e( 'Occurred', 'zw-knabbel-wp' ); ?>:
+							<?php echo esc_html( format_stored_datetime( $sync_error['occurred_at'] ) ); ?>
+						</div>
 					</td>
 				</tr>
 				<?php endif; ?>
 			</table>
 		</div>
 		<div class="knabbel-articles-footer">
-			<?php if ( $is_error ) : ?>
-			<button type="button"
-				class="knabbel-btn knabbel-btn-secondary"
-				id="knabbel-retry-btn"
-				data-post-id="<?php echo intval( $selected->ID ); ?>"
-				style="padding: 6px 12px;">
-				<?php esc_html_e( 'Retry', 'zw-knabbel-wp' ); ?>
-			</button>
-			<?php endif; ?>
 			<div class="footer-right">
 				<button type="button" class="knabbel-refresh" onclick="<?php echo esc_attr( $refresh_js ); ?>">
 					<?php esc_html_e( 'Refresh', 'zw-knabbel-wp' ); ?>

--- a/includes/ai-handler.php
+++ b/includes/ai-handler.php
@@ -144,21 +144,22 @@ function ai_generate_content( string $content, int $current_post_id ): ?string {
 
 	$model_preference = ai_parse_model_setting( $options['ai_model'] );
 
-	$max_attempts = 3;
-	for ( $attempt = 1; $attempt <= $max_attempts; ++$attempt ) {
+	// The prompt builder stores caught exceptions, so every attempt needs a fresh instance.
+	$build_prompt = static function () use ( $messages, $instruction, $model_preference ): \WP_AI_Client_Prompt_Builder {
 		$prompt = wp_ai_client_prompt( $messages )
 			->using_system_instruction( $instruction )
 			->using_max_tokens( 1000 );
-		if ( null !== $model_preference ) {
-			$prompt = $prompt->using_model_preference( $model_preference );
-		}
+		return null === $model_preference ? $prompt : $prompt->using_model_preference( $model_preference );
+	};
 
-		if ( 1 === $attempt && ! $prompt->is_supported_for_text_generation() ) {
-			log( 'error', 'AiHandler', 'WordPress AI Client does not support text generation for this prompt' );
-			return null;
-		}
+	if ( ! $build_prompt()->is_supported_for_text_generation() ) {
+		log( 'error', 'AiHandler', 'WordPress AI Client does not support text generation for this prompt' );
+		return null;
+	}
 
-		$result = $prompt->generate_text();
+	$max_attempts = 3;
+	for ( $attempt = 1; $attempt <= $max_attempts; ++$attempt ) {
+		$result = $build_prompt()->generate_text();
 
 		if ( is_wp_error( $result ) ) {
 			log(

--- a/includes/story-status.php
+++ b/includes/story-status.php
@@ -28,4 +28,21 @@ enum StoryStatus: string {
 	case Sent       = 'sent';
 	case Error      = 'error';
 	case Deleted    = 'deleted';
+
+	/**
+	 * Returns the translated display label.
+	 *
+	 * @since 0.7.0
+	 * @return string Human-readable status label.
+	 */
+	public function label(): string {
+		// phpcs:ignore PHPCompatibility.Variables.ForbiddenThisUseContexts.OutsideObjectContext -- Enum instance method; the sniff predates PHP 8.1 enums.
+		return match ( $this ) {
+			self::Scheduled  => __( 'Scheduled', 'zw-knabbel-wp' ),
+			self::Processing => __( 'Processing', 'zw-knabbel-wp' ),
+			self::Sent       => __( 'Sent', 'zw-knabbel-wp' ),
+			self::Error      => __( 'Error', 'zw-knabbel-wp' ),
+			self::Deleted    => __( 'Deleted', 'zw-knabbel-wp' ),
+		};
+	}
 }

--- a/languages/zw-knabbel-wp-nl_NL.po
+++ b/languages/zw-knabbel-wp-nl_NL.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ZuidWest Knabbel 0.7.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/zw-knabbel-wp\n"
-"POT-Creation-Date: 2026-08-11T20:01:30+00:00\n"
+"POT-Creation-Date: 2026-08-13T23:57:24+00:00\n"
 "PO-Revision-Date: 2026-08-11T14:51:44+00:00\n"
 "Last-Translator: Remon Mens\n"
 "Language-Team: Dutch\n"
@@ -13,8 +13,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. Plugin Name of the plugin
-#: zw-knabbel-wp.php includes/admin/settings.php:66
-#: includes/admin/settings.php:212
+#: zw-knabbel-wp.php includes/admin/settings.php:64
+#: includes/admin/settings.php:207
 msgid "ZuidWest Knabbel"
 msgstr "ZuidWest Knabbel"
 
@@ -62,57 +62,37 @@ msgstr "Nee"
 msgid "Babbel sync warning"
 msgstr "Waarschuwing bij Babbel-synchronisatie"
 
-#: includes/admin/metabox.php:133 includes/admin/settings.php:554
-#: includes/admin/settings.php:733
+#: includes/admin/metabox.php:133 includes/admin/settings.php:510
+#: includes/admin/settings.php:680
 msgid "Status"
 msgstr "Status"
 
-#: includes/admin/metabox.php:137 includes/admin/settings.php:677
-msgid "Scheduled"
-msgstr "Ingepland"
-
-#: includes/admin/metabox.php:138 includes/admin/settings.php:678
-msgid "Processing"
-msgstr "Bezig"
-
-#: includes/admin/metabox.php:139 includes/admin/settings.php:679
-msgid "Sent"
-msgstr "Verzonden"
-
-#: includes/admin/metabox.php:140 includes/admin/settings.php:680
-msgid "Error"
-msgstr "Fout"
-
-#: includes/admin/metabox.php:141
-msgid "Deleted"
-msgstr "Verwijderd"
-
-#: includes/admin/metabox.php:143
+#: includes/admin/metabox.php:136
 msgid "—"
 msgstr "—"
 
-#: includes/admin/metabox.php:149
+#: includes/admin/metabox.php:142
 msgid "Last status change:"
 msgstr "Laatste statuswijziging:"
 
-#: includes/admin/metabox.php:159
+#: includes/admin/metabox.php:148
 msgid "Story ID"
 msgstr "Verhaal-ID"
 
-#: includes/admin/metabox.php:165
+#: includes/admin/metabox.php:154
 msgid "Scheduled:"
 msgstr "Ingepland:"
 
-#: includes/admin/metabox.php:174 includes/admin/settings.php:771
+#: includes/admin/metabox.php:163 includes/admin/settings.php:718
 msgid "Last sync error"
 msgstr "Laatste synchronisatiefout"
 
-#: includes/admin/metabox.php:180 includes/admin/settings.php:776
+#: includes/admin/metabox.php:168 includes/admin/settings.php:723
 msgid "Operation"
 msgstr "Bewerking"
 
-#: includes/admin/metabox.php:198 includes/admin/settings.php:281
-#: includes/admin/settings.php:755 includes/admin/settings.php:760
+#: includes/admin/metabox.php:180 includes/admin/settings.php:270
+#: includes/admin/settings.php:702 includes/admin/settings.php:707
 msgid "Message"
 msgstr "Bericht"
 
@@ -120,91 +100,87 @@ msgstr "Bericht"
 msgid "You do not have sufficient permissions to perform this action."
 msgstr "Je hebt onvoldoende rechten om deze actie uit te voeren."
 
-#: includes/admin/settings.php:65
+#: includes/admin/settings.php:63
 msgid "ZuidWest Knabbel Settings"
 msgstr "ZuidWest Knabbel Instellingen"
 
-#: includes/admin/settings.php:163
+#: includes/admin/settings.php:162
 msgid "You do not have sufficient permissions to view this page."
 msgstr "Je hebt onvoldoende rechten om deze pagina te bekijken."
 
-#: includes/admin/settings.php:188
+#: includes/admin/settings.php:187
 msgid "Testing..."
 msgstr "Testen..."
 
-#: includes/admin/settings.php:189 includes/admin/settings.php:424
+#: includes/admin/settings.php:188 includes/admin/settings.php:379
 msgid "Test API Connection"
 msgstr "Test API-verbinding"
 
-#: includes/admin/settings.php:190
+#: includes/admin/settings.php:189
 msgid "An error occurred"
 msgstr "Er is een fout opgetreden"
 
-#: includes/admin/settings.php:203
+#: includes/admin/settings.php:202
 msgid "Recent errors cleared."
 msgstr "Recente fouten gewist."
 
-#: includes/admin/settings.php:207
-msgid "Recent errors could not be cleared. Please try again."
-msgstr "Recente fouten konden niet worden gewist. Probeer het opnieuw."
-
-#: includes/admin/settings.php:214
+#: includes/admin/settings.php:209
 msgid "Wijzigingen opslaan"
 msgstr "Wijzigingen opslaan"
 
-#: includes/admin/settings.php:272
+#: includes/admin/settings.php:261
 msgid "Recent Errors"
 msgstr "Recente fouten"
 
-#: includes/admin/settings.php:279
+#: includes/admin/settings.php:268
 msgid "Time"
 msgstr "Tijd"
 
-#: includes/admin/settings.php:280
+#: includes/admin/settings.php:269
 msgid "Component"
 msgstr "Onderdeel"
 
-#: includes/admin/settings.php:287
+#: includes/admin/settings.php:276
 msgid "No valid recent errors to display."
 msgstr "Geen geldige recente fouten om weer te geven."
 
-#: includes/admin/settings.php:318
+#: includes/admin/settings.php:295
 msgid "Clear Errors"
 msgstr "Fouten wissen"
 
-#: includes/admin/settings.php:359
+#: includes/admin/settings.php:314
 msgid "Babbel API"
 msgstr "Babbel API"
 
-#: includes/admin/settings.php:363
+#: includes/admin/settings.php:318
 msgid "Configure the Babbel API settings."
 msgstr "Configureer de Babbel API-instellingen."
 
-#: includes/admin/settings.php:368
+#: includes/admin/settings.php:323
 msgid "Babbel API Base URL"
 msgstr "Babbel API basis-URL"
 
-#: includes/admin/settings.php:377
+#: includes/admin/settings.php:332
 msgid "The base URL of the Babbel API (without trailing slash)."
 msgstr "De basis-URL van de Babbel API (zonder afsluitende slash)."
 
-#: includes/admin/settings.php:384
+#: includes/admin/settings.php:339
 msgid "Babbel API Username"
 msgstr "Babbel API-gebruikersnaam"
 
-#: includes/admin/settings.php:391
+#: includes/admin/settings.php:346
 msgid "username"
 msgstr "gebruikersnaam"
 
-#: includes/admin/settings.php:396
+#: includes/admin/settings.php:351
 msgid "Babbel API Password"
 msgstr "Babbel API-wachtwoord"
 
-#: includes/admin/settings.php:414
+#: includes/admin/settings.php:369
 msgid "Enable Debug Mode"
 msgstr "Debug-modus inschakelen"
 
-#: includes/admin/settings.php:418
+#: includes/admin/settings.php:373
 msgid ""
 "Show debug information and status in the sidebar. Only enable for "
 "troubleshooting."
@@ -212,43 +188,43 @@ msgstr ""
 "Toon debug-informatie en status in de zijbalk. Alleen inschakelen voor "
 "probleemoplossing."
 
-#: includes/admin/settings.php:445
+#: includes/admin/settings.php:401
 msgid "AI Generation"
 msgstr "AI-generatie"
 
-#: includes/admin/settings.php:449
+#: includes/admin/settings.php:405
 msgid "WordPress selects a suitable model from your configured AI providers."
 msgstr ""
 "WordPress selecteert een geschikt model uit je geconfigureerde AI-providers."
 
-#: includes/admin/settings.php:451
+#: includes/admin/settings.php:407
 msgid "Manage AI providers"
 msgstr "AI-providers beheren"
 
-#: includes/admin/settings.php:458
+#: includes/admin/settings.php:414
 msgid "AI Model"
 msgstr "AI-model"
 
-#: includes/admin/settings.php:461
+#: includes/admin/settings.php:417
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: includes/admin/settings.php:473
+#: includes/admin/settings.php:429
 msgid ""
 "Choose a configured text model, or let WordPress select one automatically."
 msgstr ""
 "Kies een geconfigureerd tekstmodel of laat WordPress er automatisch een "
 "selecteren."
 
-#: includes/admin/settings.php:480
+#: includes/admin/settings.php:436
 msgid "No configured text generation models are available."
 msgstr "Er zijn geen geconfigureerde modellen voor tekstgeneratie beschikbaar."
 
-#: includes/admin/settings.php:486
+#: includes/admin/settings.php:442
 msgid "Speech Text Generation Prompt"
 msgstr "Prompt voor spreektekstgeneratie"
 
-#: includes/admin/settings.php:494
+#: includes/admin/settings.php:450
 msgid ""
 "Prompt for converting to radio-friendly speech text. Leave empty for default "
 "prompt."
@@ -256,99 +232,95 @@ msgstr ""
 "Prompt voor het converteren naar radiogeschikte spreektekst. Laat leeg voor "
 "standaardprompt."
 
-#: includes/admin/settings.php:510
+#: includes/admin/settings.php:466
 msgid "Sun"
 msgstr "Zo"
 
-#: includes/admin/settings.php:511
+#: includes/admin/settings.php:467
 msgid "Mon"
 msgstr "Ma"
 
-#: includes/admin/settings.php:512
+#: includes/admin/settings.php:468
 msgid "Tue"
 msgstr "Di"
 
-#: includes/admin/settings.php:513
+#: includes/admin/settings.php:469
 msgid "Wed"
 msgstr "Wo"
 
-#: includes/admin/settings.php:514
+#: includes/admin/settings.php:470
 msgid "Thu"
 msgstr "Do"
 
-#: includes/admin/settings.php:515
+#: includes/admin/settings.php:471
 msgid "Fri"
 msgstr "Vr"
 
-#: includes/admin/settings.php:516
+#: includes/admin/settings.php:472
 msgid "Sat"
 msgstr "Za"
 
-#: includes/admin/settings.php:523
+#: includes/admin/settings.php:479
 msgid "Story Defaults"
 msgstr "Standaardinstellingen verhaal"
 
-#: includes/admin/settings.php:528
+#: includes/admin/settings.php:484
 msgid "Start Date (days from now)"
 msgstr "Startdatum (dagen vanaf nu)"
 
-#: includes/admin/settings.php:536
+#: includes/admin/settings.php:492
 msgid "Number of days from publication for start date."
 msgstr "Aantal dagen vanaf publicatie voor startdatum."
 
-#: includes/admin/settings.php:541
+#: includes/admin/settings.php:497
 msgid "End Date (days from now)"
 msgstr "Einddatum (dagen vanaf nu)"
 
-#: includes/admin/settings.php:549
+#: includes/admin/settings.php:505
 msgid "Number of days from publication for end date."
 msgstr "Aantal dagen vanaf publicatie voor einddatum."
 
-#: includes/admin/settings.php:563
+#: includes/admin/settings.php:519
 msgid "Active"
 msgstr "Actief"
 
-#: includes/admin/settings.php:568
+#: includes/admin/settings.php:524
 msgid "Days"
 msgstr "Dagen"
 
-#: includes/admin/settings.php:586
+#: includes/admin/settings.php:542
 msgid "Which days the story may be broadcast."
 msgstr "Op welke dagen het verhaal uitgezonden mag worden."
 
-#: includes/admin/settings.php:704
+#: includes/admin/settings.php:651
 msgid "Knabbel Story Debug Overview"
 msgstr "Knabbel verhaal debug-overzicht"
 
-#: includes/admin/settings.php:718
+#: includes/admin/settings.php:665
 msgid "Show"
 msgstr "Tonen"
 
-#: includes/admin/settings.php:724
+#: includes/admin/settings.php:671
 msgid "Article"
 msgstr "Artikel"
 
-#: includes/admin/settings.php:742
+#: includes/admin/settings.php:689
 msgid "Last status change"
 msgstr "Laatste statuswijziging"
 
-#: includes/admin/settings.php:749 includes/admin/settings.php:765
+#: includes/admin/settings.php:696 includes/admin/settings.php:712
 msgid "Babbel ID"
 msgstr "Babbel ID"
 
-#: includes/admin/settings.php:761 zw-knabbel-wp.php:698
+#: includes/admin/settings.php:708 zw-knabbel-wp.php:664
 msgid "Story is being processed..."
 msgstr "Verhaal wordt verwerkt..."
 
-#: includes/admin/settings.php:785
+#: includes/admin/settings.php:728
 msgid "Occurred"
 msgstr "Opgetreden"
 
-#: includes/admin/settings.php:801
-msgid "Retry"
-msgstr "Opnieuw verzenden"
-
-#: includes/admin/settings.php:806
+#: includes/admin/settings.php:739
 msgid "Refresh"
 msgstr "Vernieuwen"
 
@@ -380,7 +352,8 @@ msgstr "API-verbinding mislukt: "
 msgid "API error: HTTP %1$d - %2$s"
 msgstr "API-fout: HTTP %1$d - %2$s"
 
-#: includes/babbel-api.php:272 includes/babbel-api.php:744
+#: includes/babbel-api.php:272 includes/babbel-api.php:743
+#: includes/babbel-api.php:748
 msgid "Invalid API response"
 msgstr "Ongeldige API-respons"
 
@@ -392,7 +365,7 @@ msgstr "API-fout"
 msgid "No story ID received from API"
 msgstr "Geen verhaal-ID ontvangen van API"
 
-#: includes/babbel-api.php:325 zw-knabbel-wp.php:753
+#: includes/babbel-api.php:325 zw-knabbel-wp.php:719
 msgid "Story created successfully"
 msgstr "Verhaal succesvol aangemaakt"
 
@@ -445,7 +418,7 @@ msgid "Babbel API base URL not configured"
 msgstr "Babbel API basis-URL niet geconfigureerd"
 
 #. translators: %d is the HTTP status code.
-#: includes/babbel-api.php:731
+#: includes/babbel-api.php:730
 #, php-format
 msgid "API error: HTTP %d"
 msgstr "API-fout: HTTP %d"
@@ -486,25 +459,50 @@ msgstr "Verwerking ingepland"
 msgid "Could not schedule action"
 msgstr "Kon actie niet inplannen"
 
-#: zw-knabbel-wp.php:626
+#: includes/story-status.php:41
+msgid "Scheduled"
+msgstr "Ingepland"
+
+#: includes/story-status.php:42
+msgid "Processing"
+msgstr "Bezig"
+
+#: includes/story-status.php:43
+msgid "Sent"
+msgstr "Verzonden"
+
+#: includes/story-status.php:44
+msgid "Error"
+msgstr "Fout"
+
+#: includes/story-status.php:45
+msgid "Deleted"
+msgstr "Verwijderd"
+
+#: zw-knabbel-wp.php:600
 msgid "Insufficient permissions"
 msgstr "Onvoldoende rechten"
 
-#: zw-knabbel-wp.php:662
-msgid "Already sent — skipping"
-msgstr "Al verzonden — wordt overgeslagen"
-
-#: zw-knabbel-wp.php:674
+#: zw-knabbel-wp.php:640
 msgid "Post not found"
 msgstr "Bericht niet gevonden"
 
-#: zw-knabbel-wp.php:687
+#: zw-knabbel-wp.php:653
 msgid "Send to Babbel is disabled for this post"
 msgstr "Verzenden naar Babbel is uitgeschakeld voor dit bericht"
 
-#: zw-knabbel-wp.php:714
+#: zw-knabbel-wp.php:680
 msgid "Could not generate speech text"
 msgstr "Kon spreektekst niet genereren"
+
+#~ msgid "Recent errors could not be cleared. Please try again."
+#~ msgstr "Recente fouten konden niet worden gewist. Probeer het opnieuw."
+
+#~ msgid "Retry"
+#~ msgstr "Opnieuw verzenden"
+
+#~ msgid "Already sent — skipping"
+#~ msgstr "Al verzonden — wordt overgeslagen"
 
 #~ msgid "Few-shot Examples"
 #~ msgstr "Few-shot voorbeelden"

--- a/languages/zw-knabbel-wp.pot
+++ b/languages/zw-knabbel-wp.pot
@@ -9,15 +9,15 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-08-11T20:01:30+00:00\n"
+"POT-Creation-Date: 2026-08-13T23:57:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: zw-knabbel-wp\n"
 
 #. Plugin Name of the plugin
 #: zw-knabbel-wp.php
-#: includes/admin/settings.php:66
-#: includes/admin/settings.php:212
+#: includes/admin/settings.php:64
+#: includes/admin/settings.php:207
 msgid "ZuidWest Knabbel"
 msgstr ""
 
@@ -62,65 +62,41 @@ msgid "Babbel sync warning"
 msgstr ""
 
 #: includes/admin/metabox.php:133
-#: includes/admin/settings.php:554
-#: includes/admin/settings.php:733
+#: includes/admin/settings.php:510
+#: includes/admin/settings.php:680
 msgid "Status"
 msgstr ""
 
-#: includes/admin/metabox.php:137
-#: includes/admin/settings.php:677
-msgid "Scheduled"
-msgstr ""
-
-#: includes/admin/metabox.php:138
-#: includes/admin/settings.php:678
-msgid "Processing"
-msgstr ""
-
-#: includes/admin/metabox.php:139
-#: includes/admin/settings.php:679
-msgid "Sent"
-msgstr ""
-
-#: includes/admin/metabox.php:140
-#: includes/admin/settings.php:680
-msgid "Error"
-msgstr ""
-
-#: includes/admin/metabox.php:141
-msgid "Deleted"
-msgstr ""
-
-#: includes/admin/metabox.php:143
+#: includes/admin/metabox.php:136
 msgid "—"
 msgstr ""
 
-#: includes/admin/metabox.php:149
+#: includes/admin/metabox.php:142
 msgid "Last status change:"
 msgstr ""
 
-#: includes/admin/metabox.php:159
+#: includes/admin/metabox.php:148
 msgid "Story ID"
 msgstr ""
 
-#: includes/admin/metabox.php:165
+#: includes/admin/metabox.php:154
 msgid "Scheduled:"
 msgstr ""
 
-#: includes/admin/metabox.php:174
-#: includes/admin/settings.php:771
+#: includes/admin/metabox.php:163
+#: includes/admin/settings.php:718
 msgid "Last sync error"
 msgstr ""
 
-#: includes/admin/metabox.php:180
-#: includes/admin/settings.php:776
+#: includes/admin/metabox.php:168
+#: includes/admin/settings.php:723
 msgid "Operation"
 msgstr ""
 
-#: includes/admin/metabox.php:198
-#: includes/admin/settings.php:281
-#: includes/admin/settings.php:755
-#: includes/admin/settings.php:760
+#: includes/admin/metabox.php:180
+#: includes/admin/settings.php:270
+#: includes/admin/settings.php:702
+#: includes/admin/settings.php:707
 msgid "Message"
 msgstr ""
 
@@ -128,226 +104,218 @@ msgstr ""
 msgid "You do not have sufficient permissions to perform this action."
 msgstr ""
 
-#: includes/admin/settings.php:65
+#: includes/admin/settings.php:63
 msgid "ZuidWest Knabbel Settings"
 msgstr ""
 
-#: includes/admin/settings.php:163
+#: includes/admin/settings.php:162
 msgid "You do not have sufficient permissions to view this page."
 msgstr ""
 
-#: includes/admin/settings.php:188
+#: includes/admin/settings.php:187
 msgid "Testing..."
 msgstr ""
 
-#: includes/admin/settings.php:189
-#: includes/admin/settings.php:424
+#: includes/admin/settings.php:188
+#: includes/admin/settings.php:379
 msgid "Test API Connection"
 msgstr ""
 
-#: includes/admin/settings.php:190
+#: includes/admin/settings.php:189
 msgid "An error occurred"
 msgstr ""
 
-#: includes/admin/settings.php:203
+#: includes/admin/settings.php:202
 msgid "Recent errors cleared."
 msgstr ""
 
-#: includes/admin/settings.php:207
-msgid "Recent errors could not be cleared. Please try again."
-msgstr ""
-
-#: includes/admin/settings.php:214
+#: includes/admin/settings.php:209
 msgid "Wijzigingen opslaan"
 msgstr ""
 
-#: includes/admin/settings.php:272
+#: includes/admin/settings.php:261
 msgid "Recent Errors"
 msgstr ""
 
-#: includes/admin/settings.php:279
+#: includes/admin/settings.php:268
 msgid "Time"
 msgstr ""
 
-#: includes/admin/settings.php:280
+#: includes/admin/settings.php:269
 msgid "Component"
 msgstr ""
 
-#: includes/admin/settings.php:287
+#: includes/admin/settings.php:276
 msgid "No valid recent errors to display."
 msgstr ""
 
-#: includes/admin/settings.php:318
+#: includes/admin/settings.php:295
 msgid "Clear Errors"
 msgstr ""
 
-#: includes/admin/settings.php:359
+#: includes/admin/settings.php:314
 msgid "Babbel API"
 msgstr ""
 
-#: includes/admin/settings.php:363
+#: includes/admin/settings.php:318
 msgid "Configure the Babbel API settings."
 msgstr ""
 
-#: includes/admin/settings.php:368
+#: includes/admin/settings.php:323
 msgid "Babbel API Base URL"
 msgstr ""
 
-#: includes/admin/settings.php:377
+#: includes/admin/settings.php:332
 msgid "The base URL of the Babbel API (without trailing slash)."
 msgstr ""
 
-#: includes/admin/settings.php:384
+#: includes/admin/settings.php:339
 msgid "Babbel API Username"
 msgstr ""
 
-#: includes/admin/settings.php:391
+#: includes/admin/settings.php:346
 msgid "username"
 msgstr ""
 
-#: includes/admin/settings.php:396
+#: includes/admin/settings.php:351
 msgid "Babbel API Password"
 msgstr ""
 
-#: includes/admin/settings.php:414
+#: includes/admin/settings.php:369
 msgid "Enable Debug Mode"
 msgstr ""
 
-#: includes/admin/settings.php:418
+#: includes/admin/settings.php:373
 msgid "Show debug information and status in the sidebar. Only enable for troubleshooting."
 msgstr ""
 
-#: includes/admin/settings.php:445
+#: includes/admin/settings.php:401
 msgid "AI Generation"
 msgstr ""
 
-#: includes/admin/settings.php:449
+#: includes/admin/settings.php:405
 msgid "WordPress selects a suitable model from your configured AI providers."
 msgstr ""
 
-#: includes/admin/settings.php:451
+#: includes/admin/settings.php:407
 msgid "Manage AI providers"
 msgstr ""
 
-#: includes/admin/settings.php:458
+#: includes/admin/settings.php:414
 msgid "AI Model"
 msgstr ""
 
-#: includes/admin/settings.php:461
+#: includes/admin/settings.php:417
 msgid "Automatic"
 msgstr ""
 
-#: includes/admin/settings.php:473
+#: includes/admin/settings.php:429
 msgid "Choose a configured text model, or let WordPress select one automatically."
 msgstr ""
 
-#: includes/admin/settings.php:480
+#: includes/admin/settings.php:436
 msgid "No configured text generation models are available."
 msgstr ""
 
-#: includes/admin/settings.php:486
+#: includes/admin/settings.php:442
 msgid "Speech Text Generation Prompt"
 msgstr ""
 
-#: includes/admin/settings.php:494
+#: includes/admin/settings.php:450
 msgid "Prompt for converting to radio-friendly speech text. Leave empty for default prompt."
 msgstr ""
 
-#: includes/admin/settings.php:510
+#: includes/admin/settings.php:466
 msgid "Sun"
 msgstr ""
 
-#: includes/admin/settings.php:511
+#: includes/admin/settings.php:467
 msgid "Mon"
 msgstr ""
 
-#: includes/admin/settings.php:512
+#: includes/admin/settings.php:468
 msgid "Tue"
 msgstr ""
 
-#: includes/admin/settings.php:513
+#: includes/admin/settings.php:469
 msgid "Wed"
 msgstr ""
 
-#: includes/admin/settings.php:514
+#: includes/admin/settings.php:470
 msgid "Thu"
 msgstr ""
 
-#: includes/admin/settings.php:515
+#: includes/admin/settings.php:471
 msgid "Fri"
 msgstr ""
 
-#: includes/admin/settings.php:516
+#: includes/admin/settings.php:472
 msgid "Sat"
 msgstr ""
 
-#: includes/admin/settings.php:523
+#: includes/admin/settings.php:479
 msgid "Story Defaults"
 msgstr ""
 
-#: includes/admin/settings.php:528
+#: includes/admin/settings.php:484
 msgid "Start Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:536
+#: includes/admin/settings.php:492
 msgid "Number of days from publication for start date."
 msgstr ""
 
-#: includes/admin/settings.php:541
+#: includes/admin/settings.php:497
 msgid "End Date (days from now)"
 msgstr ""
 
-#: includes/admin/settings.php:549
+#: includes/admin/settings.php:505
 msgid "Number of days from publication for end date."
 msgstr ""
 
-#: includes/admin/settings.php:563
+#: includes/admin/settings.php:519
 msgid "Active"
 msgstr ""
 
-#: includes/admin/settings.php:568
+#: includes/admin/settings.php:524
 msgid "Days"
 msgstr ""
 
-#: includes/admin/settings.php:586
+#: includes/admin/settings.php:542
 msgid "Which days the story may be broadcast."
 msgstr ""
 
-#: includes/admin/settings.php:704
+#: includes/admin/settings.php:651
 msgid "Knabbel Story Debug Overview"
 msgstr ""
 
-#: includes/admin/settings.php:718
+#: includes/admin/settings.php:665
 msgid "Show"
 msgstr ""
 
-#: includes/admin/settings.php:724
+#: includes/admin/settings.php:671
 msgid "Article"
 msgstr ""
 
-#: includes/admin/settings.php:742
+#: includes/admin/settings.php:689
 msgid "Last status change"
 msgstr ""
 
-#: includes/admin/settings.php:749
-#: includes/admin/settings.php:765
+#: includes/admin/settings.php:696
+#: includes/admin/settings.php:712
 msgid "Babbel ID"
 msgstr ""
 
-#: includes/admin/settings.php:761
-#: zw-knabbel-wp.php:698
+#: includes/admin/settings.php:708
+#: zw-knabbel-wp.php:664
 msgid "Story is being processed..."
 msgstr ""
 
-#: includes/admin/settings.php:785
+#: includes/admin/settings.php:728
 msgid "Occurred"
 msgstr ""
 
-#: includes/admin/settings.php:801
-msgid "Retry"
-msgstr ""
-
-#: includes/admin/settings.php:806
+#: includes/admin/settings.php:739
 msgid "Refresh"
 msgstr ""
 
@@ -387,7 +355,8 @@ msgid "API error: HTTP %1$d - %2$s"
 msgstr ""
 
 #: includes/babbel-api.php:272
-#: includes/babbel-api.php:744
+#: includes/babbel-api.php:743
+#: includes/babbel-api.php:748
 msgid "Invalid API response"
 msgstr ""
 
@@ -400,7 +369,7 @@ msgid "No story ID received from API"
 msgstr ""
 
 #: includes/babbel-api.php:325
-#: zw-knabbel-wp.php:753
+#: zw-knabbel-wp.php:719
 msgid "Story created successfully"
 msgstr ""
 
@@ -455,7 +424,7 @@ msgid "Babbel API base URL not configured"
 msgstr ""
 
 #. translators: %d is the HTTP status code.
-#: includes/babbel-api.php:731
+#: includes/babbel-api.php:730
 #, php-format
 msgid "API error: HTTP %d"
 msgstr ""
@@ -497,22 +466,38 @@ msgstr ""
 msgid "Could not schedule action"
 msgstr ""
 
-#: zw-knabbel-wp.php:626
+#: includes/story-status.php:41
+msgid "Scheduled"
+msgstr ""
+
+#: includes/story-status.php:42
+msgid "Processing"
+msgstr ""
+
+#: includes/story-status.php:43
+msgid "Sent"
+msgstr ""
+
+#: includes/story-status.php:44
+msgid "Error"
+msgstr ""
+
+#: includes/story-status.php:45
+msgid "Deleted"
+msgstr ""
+
+#: zw-knabbel-wp.php:600
 msgid "Insufficient permissions"
 msgstr ""
 
-#: zw-knabbel-wp.php:662
-msgid "Already sent — skipping"
-msgstr ""
-
-#: zw-knabbel-wp.php:674
+#: zw-knabbel-wp.php:640
 msgid "Post not found"
 msgstr ""
 
-#: zw-knabbel-wp.php:687
+#: zw-knabbel-wp.php:653
 msgid "Send to Babbel is disabled for this post"
 msgstr ""
 
-#: zw-knabbel-wp.php:714
+#: zw-knabbel-wp.php:680
 msgid "Could not generate speech text"
 msgstr ""

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -31,7 +31,7 @@ project, removes it after the run, and writes combined container logs to
 
 ## Covered scenarios
 
-The scenario catalog (E2E-001 through E2E-018) lives in the `run()` method of
+The scenario catalog (E2E-001 through E2E-019) lives in the `run()` method of
 `suite.php`; the runner prints each scenario ID and title during execution.
 
 Before the PHP scenarios, Playwright drives the real WordPress admin UI in

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -137,7 +137,7 @@ wp plugin activate zw-knabbel-wp
 wp option update connectors_ai_openai_api_key e2e-openai-key
 # The dollar-prefixed variables are evaluated by PHP inside the container.
 # shellcheck disable=SC2016
-wp eval '$settings = get_option( "knabbel_settings", array() ); $settings["title_prompt"] = "legacy"; $settings["openai_api_key"] = "legacy-secret"; $settings["openai_model"] = "legacy-model"; update_option( "knabbel_settings", $settings );'
+wp eval '$settings = get_option( "knabbel_settings", array() ); $settings["title_prompt"] = "legacy"; $settings["openai_api_key"] = "legacy-secret"; $settings["openai_model"] = "legacy-model"; update_option( "knabbel_settings", $settings ); update_option( "knabbel_version", "0.6.0" );'
 # shellcheck disable=SC2016
 wp eval '$settings = get_option( "knabbel_settings", array() ); if ( array_intersect( array( "title_prompt", "openai_api_key", "openai_model" ), array_keys( $settings ) ) ) { throw new RuntimeException( "Legacy AI settings were not removed on init." ); } if ( 1 !== ( $settings["start_days_offset"] ?? null ) || "draft" !== ( $settings["default_status"] ?? null ) ) { throw new RuntimeException( "Plugin activation defaults are incorrect." ); }'
 

--- a/tests/e2e/suite.php
+++ b/tests/e2e/suite.php
@@ -85,7 +85,8 @@ final class Knabbel_E2E_Suite {
 		$this->run_case( 'E2E-015', 'processing state prevents duplicate scheduling', $this->test_in_flight_state_guards( ... ) );
 		$this->run_case( 'E2E-016', 'untrash honors a disabled checkbox', $this->test_untrash_with_checkbox_disabled( ... ) );
 		$this->run_case( 'E2E-017', 'delete and restore failures remain retryable', $this->test_delete_and_restore_failures( ... ) );
-		$this->run_case( 'E2E-018', 'deactivation clears sessions, caches and scheduled actions', $this->test_deactivation_cleanup( ... ) );
+		$this->run_case( 'E2E-018', 'stored Unix timestamps retain their meaning after serialization', $this->test_stored_datetime_formatting( ... ) );
+		$this->run_case( 'E2E-019', 'deactivation clears sessions, caches and scheduled actions', $this->test_deactivation_cleanup( ... ) );
 
 		WP_CLI::success( sprintf( '%d E2E scenarios passed with %d assertions.', $this->case_count, $this->assertion_count ) );
 	}
@@ -799,6 +800,20 @@ final class Knabbel_E2E_Suite {
 		$this->assert_same( true, ! isset( $state['last_sync_error'] ), 'Successful restore retry must clear its previous error.' );
 		$story = $this->get_babbel_story( $story_id );
 		$this->assert_same( $retry_title, $story['title'] ?? null, 'Successful restore retry must synchronize the current title.' );
+	}
+
+	/**
+	 * Verifies integer timestamps survive WordPress option serialization.
+	 */
+	private function test_stored_datetime_formatting(): void {
+		$timestamp  = 1_700_000_000;
+		$serialized = maybe_unserialize( maybe_serialize( (string) $timestamp ) );
+
+		$this->assert_same(
+			KnabbelWP\format_stored_datetime( $timestamp ),
+			KnabbelWP\format_stored_datetime( $serialized ),
+			'Integer and serialized-string timestamps must render identically.'
+		);
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -22,6 +22,7 @@ KnabbelWP\babbel_cleanup_sessions();
 delete_option( 'knabbel_recent_errors' );
 delete_option( 'knabbel_migration_status_changed_at' );
 delete_option( 'knabbel_few_shot_examples' );
+delete_option( 'knabbel_version' );
 
 // Clean up any remaining Action Scheduler jobs.
 if ( function_exists( 'as_unschedule_all_actions' ) ) {

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -410,7 +410,9 @@ function get_story_sync_error( array $state ): ?array {
  * @return string Localized date and time in the site's display format.
  */
 function format_stored_datetime( int|string $datetime ): string {
-	$timestamp = is_int( $datetime ) ? $datetime : strtotime( $datetime . ' ' . wp_timezone_string() );
+	$timestamp = is_int( $datetime ) || false !== filter_var( $datetime, FILTER_VALIDATE_INT )
+		? (int) $datetime
+		: strtotime( $datetime . ' ' . wp_timezone_string() );
 	if ( false === $timestamp ) {
 		return (string) $datetime;
 	}

--- a/zw-knabbel-wp.php
+++ b/zw-knabbel-wp.php
@@ -74,23 +74,10 @@ function debug_enabled(): bool {
  * @phpstan-param LogContext $context
  */
 function prepare_log_context_for_storage( array $context ): array {
-	return array_merge(
-		prepare_log_text_context( $context ),
-		prepare_log_scalar_context( $context ),
-		prepare_log_list_context( $context )
-	);
-}
-
-/**
- * Sanitizes textual diagnostic context.
- *
- * @since 0.5.0
- * @param array<string, mixed> $context Raw log context.
- * @return array<string, string>
- */
-function prepare_log_text_context( array $context ): array {
 	$safe_context = array();
-	$text_fields  = array(
+
+	// Textual diagnostic fields, bounded per field.
+	$text_fields = array(
 		'endpoint'   => 500,
 		'story_id'   => 100,
 		'error'      => 500,
@@ -99,58 +86,32 @@ function prepare_log_text_context( array $context ): array {
 		'json_error' => 500,
 		'error_code' => 100,
 	);
-
 	foreach ( $text_fields as $key => $max_length ) {
-		if ( ! isset( $context[ $key ] ) || ! is_scalar( $context[ $key ] ) ) {
-			continue;
+		if ( isset( $context[ $key ] ) && is_scalar( $context[ $key ] ) ) {
+			$value                = sanitize_textarea_field( (string) $context[ $key ] );
+			$safe_context[ $key ] = wp_html_excerpt( $value, $max_length, '' );
 		}
-
-		$value                = sanitize_textarea_field( (string) $context[ $key ] );
-		$safe_context[ $key ] = wp_html_excerpt( $value, $max_length, '' );
 	}
 
-	return $safe_context;
-}
-
-/**
- * Sanitizes scalar diagnostic context.
- *
- * @since 0.5.0
- * @param array<string, mixed> $context Raw log context.
- * @return array<string, int|bool>
- */
-function prepare_log_scalar_context( array $context ): array {
-	$safe_context = array();
-
+	// Numeric diagnostic fields.
 	foreach ( array( 'post_id', 'response_code' ) as $key ) {
 		if ( isset( $context[ $key ] ) && is_numeric( $context[ $key ] ) ) {
 			$safe_context[ $key ] = (int) $context[ $key ];
 		}
 	}
 
-	return $safe_context;
-}
-
-/**
- * Sanitizes list-valued diagnostic context.
- *
- * @since 0.5.0
- * @param array<string, mixed> $context Raw log context.
- * @return array<string, list<string>>
- */
-function prepare_log_list_context( array $context ): array {
-	if ( ! isset( $context['fields'] ) || ! is_array( $context['fields'] ) ) {
-		return array();
-	}
-
-	$fields = array();
-	foreach ( array_slice( $context['fields'], 0, 20 ) as $field ) {
-		if ( is_scalar( $field ) ) {
-			$fields[] = sanitize_key( (string) $field );
+	// Bounded list of field names.
+	if ( isset( $context['fields'] ) && is_array( $context['fields'] ) ) {
+		$fields = array();
+		foreach ( array_slice( $context['fields'], 0, 20 ) as $field ) {
+			if ( is_scalar( $field ) ) {
+				$fields[] = sanitize_key( (string) $field );
+			}
 		}
+		$safe_context['fields'] = $fields;
 	}
 
-	return array( 'fields' => $fields );
+	return $safe_context;
 }
 
 /**
@@ -271,7 +232,6 @@ function append_recent_error( array $new_error ): void {
 			if ( 1 === $updated ) {
 				wp_cache_delete( $option_name, 'options' );
 				wp_cache_delete( 'alloptions', 'options' );
-				wp_cache_delete( 'notoptions', 'options' );
 				return;
 			}
 		}
@@ -416,7 +376,7 @@ function build_story_sync_error( string $message, string $operation ): array {
  *
  * @since 0.5.0
  * @param array<string, mixed> $state Story state data.
- * @return array{message: string, occurred_at: string, operation: string}|null Sync error, or null when absent or malformed.
+ * @return array{message: string, occurred_at: string, operation: string}|null Sync error, or null when absent, malformed, or blank.
  *
  * @phpstan-return LastSyncError|null
  */
@@ -428,6 +388,9 @@ function get_story_sync_error( array $state ): ?array {
 	if ( ! is_string( $error['message'] ) || ! is_string( $error['occurred_at'] ) || ! is_string( $error['operation'] ) ) {
 		return null;
 	}
+	if ( '' === trim( $error['message'] ) ) {
+		return null;
+	}
 
 	return array(
 		'message'     => $error['message'],
@@ -437,19 +400,23 @@ function get_story_sync_error( array $state ): ?array {
 }
 
 /**
- * Reports whether an error can be rendered.
+ * Formats a stored datetime for admin display.
  *
- * @since 0.5.0
- * @param array<string, mixed>|null $sync_error Sync error data.
- * @return bool Whether the sync error can be rendered.
+ * Accepts a local-time MySQL string as written by current_time( 'mysql' ), or a
+ * Unix timestamp. Falls back to the raw input when it cannot be parsed.
  *
- * @phpstan-assert-if-true !null $sync_error
+ * @since 0.7.0
+ * @param int|string $datetime Stored local-time string or Unix timestamp.
+ * @return string Localized date and time in the site's display format.
  */
-function is_story_sync_error_renderable( ?array $sync_error ): bool {
-	return null !== $sync_error
-		&& isset( $sync_error['message'] )
-		&& is_string( $sync_error['message'] )
-		&& '' !== trim( $sync_error['message'] );
+function format_stored_datetime( int|string $datetime ): string {
+	$timestamp = is_int( $datetime ) ? $datetime : strtotime( $datetime . ' ' . wp_timezone_string() );
+	if ( false === $timestamp ) {
+		return (string) $datetime;
+	}
+
+	$formatted = wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+	return false === $formatted ? (string) $datetime : $formatted;
 }
 
 /**
@@ -484,7 +451,12 @@ function calculate_story_dates( string $base_date = 'now' ): array {
  */
 function init(): void {
 	load_plugin_textdomain( 'zw-knabbel-wp', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-	cleanup_legacy_data();
+
+	// Run one-time migrations only when the installed version changes.
+	if ( KNABBEL_VERSION !== get_option( 'knabbel_version' ) ) {
+		cleanup_legacy_data();
+		update_option( 'knabbel_version', KNABBEL_VERSION, false );
+	}
 
 	// Register cron hook for async story processing (always, not just admin).
 	add_action( 'knabbel_process_story', __NAMESPACE__ . '\\process_story_async', 10, 1 );
@@ -572,10 +544,8 @@ function activate(): void {
 		// WP 6.6+ changed the default autoload behavior from 'yes' to dynamic heuristics.
 		add_option( 'knabbel_settings', default_settings(), '', true );
 
-		// Cleanup all legacy data on activation.
-		cleanup_legacy_data();
-
-		// Schedule nightly few-shot example sync.
+		// Schedule nightly few-shot example sync. Legacy cleanup runs from init()
+		// via the version gate.
 		few_shot_schedule_sync();
 }
 
@@ -596,7 +566,7 @@ function deactivate(): void {
 }
 
 /**
- * Removes deprecated settings during activation.
+ * Removes deprecated settings when the installed version changes.
  *
  * Safe to run multiple times. Keep through the migration window for settings
  * removed up to and including 0.7.0.
@@ -644,12 +614,9 @@ function ajax_test_api(): void {
  *
  * @since 0.1.0
  * @since 0.7.0 Excludes the current post from the AI few-shot examples.
- * @param int|array{post_id?: int} $post_id_or_args The WordPress post ID or Action Scheduler args array.
+ * @param int $post_id The WordPress post ID.
  */
-function process_story_async( int|array $post_id_or_args ): void {
-	// Handle both WP-Cron (int) and Action Scheduler (array) formats.
-	$post_id = is_array( $post_id_or_args ) ? (int) ( $post_id_or_args['post_id'] ?? 0 ) : $post_id_or_args;
-
+function process_story_async( int $post_id ): void {
 	if ( ! $post_id ) {
 		log( 'error', 'CronProcessor', 'Invalid post_id in process_story_async' );
 		return;
@@ -657,16 +624,10 @@ function process_story_async( int|array $post_id_or_args ): void {
 
 	log( 'info', 'CronProcessor', 'Starting async story processing', array( 'post_id' => $post_id ) );
 
-		// Send-once safety: if already sent, do nothing.
-		$existing_state = get_post_meta( $post_id, '_zw_knabbel_story_state', true );
-	if ( is_array( $existing_state ) && isset( $existing_state['status'] ) && \KnabbelWP\StoryStatus::Sent->value === $existing_state['status'] ) {
-		update_story_state(
-			$post_id,
-			array(
-				'status'  => \KnabbelWP\StoryStatus::Sent->value,
-				'message' => __( 'Already sent — skipping', 'zw-knabbel-wp' ),
-			)
-		);
+	// Send-once safety: if already sent, do nothing.
+	$existing_state = get_story_state( $post_id );
+	if ( isset( $existing_state['status'] ) && StoryStatus::Sent->value === $existing_state['status'] ) {
+		log( 'info', 'CronProcessor', 'Story already sent — skipping', array( 'post_id' => $post_id ) );
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- centralize story status labels and stored datetime formatting
- simplify admin error rendering and remove the unused retry control
- rebuild AI prompts per retry and streamline logging helpers
- gate legacy cleanup by plugin version and clean up version metadata on uninstall
- preserve few-shot quality filtering and legacy option cache safety

## Checks
- composer test
- vendor/bin/phpcs
- composer phpstan
- npm run lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin sync-error details, including clearer messages and occurrence times.
  * Prevented blank sync errors from being displayed.
  * Improved handling of unsupported content-generation requests and repeated story sends.
  * Ensured uninstall cleanup removes all plugin data.

* **Improvements**
  * Standardized story status labels and date/time formatting across the admin interface.
  * Simplified recent-error handling and clearing.
  * Removed the admin retry control.

* **Translations**
  * Updated Dutch translations and refreshed translation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->